### PR TITLE
Allow to dynamically define type constraint name

### DIFF
--- a/database/contracts.go
+++ b/database/contracts.go
@@ -47,3 +47,10 @@ type TableNamer interface {
 type Scoper interface {
 	Scope() any
 }
+
+// PgsqlOnConflictConstrainter implements the PgsqlOnConflictConstraint method,
+// which returns the primary or unique key constraint name of the PostgreSQL table.
+type PgsqlOnConflictConstrainter interface {
+	// PgsqlOnConflictConstraint returns the primary or unique key constraint name of the PostgreSQL table.
+	PgsqlOnConflictConstraint() string
+}

--- a/database/db.go
+++ b/database/db.go
@@ -232,7 +232,14 @@ func (db *DB) BuildInsertIgnoreStmt(into interface{}) (string, int) {
 		// MySQL treats UPDATE id = id as a no-op.
 		clause = fmt.Sprintf(`ON DUPLICATE KEY UPDATE "%s" = "%s"`, columns[0], columns[0])
 	case driver.PostgreSQL:
-		clause = fmt.Sprintf("ON CONFLICT ON CONSTRAINT pk_%s DO NOTHING", table)
+		var constraint string
+		if constrainter, ok := into.(PgsqlOnConflictConstrainter); ok {
+			constraint = constrainter.PgsqlOnConflictConstraint()
+		} else {
+			constraint = "pk_" + table
+		}
+
+		clause = fmt.Sprintf("ON CONFLICT ON CONSTRAINT %s DO NOTHING", constraint)
 	}
 
 	return fmt.Sprintf(
@@ -295,7 +302,14 @@ func (db *DB) BuildUpsertStmt(subject interface{}) (stmt string, placeholders in
 		clause = "ON DUPLICATE KEY UPDATE"
 		setFormat = `"%[1]s" = VALUES("%[1]s")`
 	case driver.PostgreSQL:
-		clause = fmt.Sprintf("ON CONFLICT ON CONSTRAINT pk_%s DO UPDATE SET", table)
+		var constraint string
+		if constrainter, ok := subject.(PgsqlOnConflictConstrainter); ok {
+			constraint = constrainter.PgsqlOnConflictConstraint()
+		} else {
+			constraint = "pk_" + table
+		}
+
+		clause = fmt.Sprintf("ON CONFLICT ON CONSTRAINT %s DO UPDATE SET", constraint)
 		setFormat = `"%[1]s" = EXCLUDED."%[1]s"`
 	}
 


### PR DESCRIPTION
This allows us to dynamically determine the constraint names used for the `UPSERT` and `INSERT IGNORE` statements for the PostgreSQL driver.