### PR TITLE
workflows: Fix `gosec` errors & enable code annotations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request: { }
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   go:
     runs-on: ubuntu-latest

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -39,5 +39,5 @@ func jitter(n int64) int64 {
 		return 0
 	}
 
-	return n/2 + rand.Int63n(n/2)
+	return n/2 + rand.Int63n(n/2) // #nosec G404 -- Use of weak random number generator - we don't need crypto/rand here though.
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ func FromYAMLFile(name string, v Validator) error {
 		return errors.Wrapf(ErrInvalidArgument, "non-nil pointer expected, got %T", v)
 	}
 
+	// #nosec G304 -- Potential file inclusion via variable - Its purpose is to load any file name that is passed to it, so doesn't need to validate anything.
 	f, err := os.Open(name)
 	if err != nil {
 		return errors.Wrap(err, "can't open YAML file "+name)

--- a/config/tls.go
+++ b/config/tls.go
@@ -22,7 +22,7 @@ func (t *TLS) MakeConfig(serverName string) (*tls.Config, error) {
 		return nil, nil
 	}
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if t.Cert == "" {
 		if t.Key != "" {
 			return nil, errors.New("private key given, but client certificate missing")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- Blocklisted import crypto/sha1
 	"fmt"
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
@@ -64,8 +64,10 @@ func Checksum(data interface{}) []byte {
 
 	switch data := data.(type) {
 	case string:
+		// #nosec G401 -- Use of weak cryptographic primitive - we don't intend to change this anytime soon.
 		chksm = sha1.Sum([]byte(data))
 	case []byte:
+		// #nosec G401 -- Use of weak cryptographic primitive - we don't intend to change this anytime soon.
 		chksm = sha1.Sum(data)
 	default:
 		panic(fmt.Sprintf("Unable to create checksum for type %T", data))

--- a/version/version.go
+++ b/version/version.go
@@ -124,7 +124,7 @@ func (o *osRelease) DisplayVersion() string {
 // readOsRelease reads and parses the os-release file.
 func readOsRelease() (*osRelease, error) {
 	for _, path := range []string{"/etc/os-release", "/usr/lib/os-release"} {
-		f, err := os.Open(path)
+		f, err := os.Open(path) // #nosec G304 -- Potential file inclusion via variable - Hard-coded files, so not affected by this issue.
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue // Try next path.


### PR DESCRIPTION
Enables code annotations in case of failures and fixes the actions triggered by the main branch.
https://github.com/Icinga/icinga-go-library/actions/runs/7783022809/job/21220618068

This PR suppresses also some of the reported existing `gosec` errors and solves some of them as well and drops the `only-new-issue` flag set for the go linter.

```bash
$ gosec ./...
---
Results:

Summary:
  Gosec  : dev
  Files  : 40
  Lines  : 4269
  Nosec  : 4
  Issues : 0
```