### PR TITLE
types.*: assert interface compliance not stricter than needed

### DIFF
--- a/types/binary.go
+++ b/types/binary.go
@@ -115,11 +115,11 @@ func (binary Binary) Value() (driver.Value, error) {
 
 // Assert interface compliance.
 var (
-	_ fmt.Stringer             = (*Binary)(nil)
-	_ encoding.TextMarshaler   = (*Binary)(nil)
+	_ fmt.Stringer             = Binary{}
+	_ encoding.TextMarshaler   = Binary{}
 	_ encoding.TextUnmarshaler = (*Binary)(nil)
-	_ json.Marshaler           = (*Binary)(nil)
+	_ json.Marshaler           = Binary{}
 	_ json.Unmarshaler         = (*Binary)(nil)
 	_ sql.Scanner              = (*Binary)(nil)
-	_ driver.Valuer            = (*Binary)(nil)
+	_ driver.Valuer            = Binary{}
 )

--- a/types/bool.go
+++ b/types/bool.go
@@ -96,9 +96,9 @@ func (b Bool) Value() (driver.Value, error) {
 
 // Assert interface compliance.
 var (
-	_ json.Marshaler           = (*Bool)(nil)
+	_ json.Marshaler           = Bool{}
 	_ encoding.TextUnmarshaler = (*Bool)(nil)
 	_ json.Unmarshaler         = (*Bool)(nil)
 	_ sql.Scanner              = (*Bool)(nil)
-	_ driver.Valuer            = (*Bool)(nil)
+	_ driver.Valuer            = Bool{}
 )

--- a/types/unix_milli.go
+++ b/types/unix_milli.go
@@ -107,10 +107,10 @@ func (t *UnixMilli) fromByteString(data []byte) error {
 
 // Assert interface compliance.
 var (
-	_ encoding.TextMarshaler   = (*UnixMilli)(nil)
+	_ encoding.TextMarshaler   = UnixMilli{}
 	_ encoding.TextUnmarshaler = (*UnixMilli)(nil)
-	_ json.Marshaler           = (*UnixMilli)(nil)
+	_ json.Marshaler           = UnixMilli{}
 	_ json.Unmarshaler         = (*UnixMilli)(nil)
-	_ driver.Valuer            = (*UnixMilli)(nil)
+	_ driver.Valuer            = UnixMilli{}
 	_ sql.Scanner              = (*UnixMilli)(nil)
 )

--- a/types/uuid.go
+++ b/types/uuid.go
@@ -20,5 +20,4 @@ func (uuid UUID) Value() (driver.Value, error) {
 var (
 	_ encoding.TextUnmarshaler = (*UUID)(nil)
 	_ driver.Valuer            = UUID{}
-	_ driver.Valuer            = (*UUID)(nil)
 )


### PR DESCRIPTION
I.e. match receivers, don't require a *T if a T is fine, too.