### PR TITLE
Make project name configurable

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -79,8 +79,8 @@ func Version(version, gitDescribe, gitHash string) *VersionInfo {
 }
 
 // Print writes verbose version output to stdout.
-func (v *VersionInfo) Print() {
-	fmt.Println("Icinga DB version:", v.Version)
+func (v *VersionInfo) Print(projectName string) {
+	fmt.Printf("%s version: %s\n", projectName, v.Version)
 	fmt.Println()
 
 	fmt.Println("Build information:")


### PR DESCRIPTION
Currently, the hard-coded value "Icinga DB" is printed in the `... --version` output. This PR requires you now to provide the project name when using `version.Print()`.