### PR TITLE
redis: Configurable Database

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -53,7 +53,7 @@ func NewClientFromConfig(c *Config, logger *logging.Logger) (*Client, error) {
 	options := &redis.Options{
 		Dialer:      dialWithLogging(dialer, logger),
 		Password:    c.Password,
-		DB:          0, // Use default DB,
+		DB:          c.Database,
 		ReadTimeout: c.Options.Timeout,
 		TLSConfig:   tlsConfig,
 	}

--- a/redis/config.go
+++ b/redis/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Host       string     `yaml:"host"`
 	Port       int        `yaml:"port"`
 	Password   string     `yaml:"password"`
+	Database   int        `yaml:"database" default:"0"`
 	TlsOptions config.TLS `yaml:",inline"`
 	Options    Options    `yaml:"options"`
 }


### PR DESCRIPTION
A Redis server might support multiple databases, allowing to use the same Redis for different applications. The database can either be configured for the configuration or later changed via [SELECT][0]. By default, the database 0 will be used.

While both the used go-redis library and even [Icinga 2][1] support this feature, we should expose this here and make this configurable.

As discussed in [Icinga DB issue #676][2], this is not something one might want to encourage all users to use. However, there are definitely setups where this option might come in handy.

[0]: https://redis.io/docs/latest/commands/select/
[1]: https://github.com/Icinga/icinga2/blob/bca1a8447af26313123183efa863f947f9590731/lib/icingadb/icingadb.ti#L23
[2]: https://github.com/Icinga/icingadb/issues/676