### PR TITLE
redis: Configurable Username

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -52,6 +52,7 @@ func NewClientFromConfig(c *Config, logger *logging.Logger) (*Client, error) {
 
 	options := &redis.Options{
 		Dialer:      dialWithLogging(dialer, logger),
+		Username:    c.Username,
 		Password:    c.Password,
 		DB:          0, // Use default DB,
 		ReadTimeout: c.Options.Timeout,

--- a/redis/config.go
+++ b/redis/config.go
@@ -44,6 +44,7 @@ func (o *Options) Validate() error {
 type Config struct {
 	Host       string     `yaml:"host"`
 	Port       int        `yaml:"port"`
+	Username   string     `yaml:"username"`
 	Password   string     `yaml:"password"`
 	TlsOptions config.TLS `yaml:",inline"`
 	Options    Options    `yaml:"options"`
@@ -53,6 +54,10 @@ type Config struct {
 func (r *Config) Validate() error {
 	if r.Host == "" {
 		return errors.New("Redis host missing")
+	}
+
+	if r.Username != "" && r.Password == "" {
+		return errors.New("Redis password must be set, if username is provided")
 	}
 
 	return r.Options.Validate()


### PR DESCRIPTION
The Redis ACL system was introduced with Redis 6.0. It introduced users with precisely granular permissions. This change allows Icinga DB to connect to a Redis with an ACL user.