### PR TITLE
db.DB/redis.Client: Details in Address for GetAddr

### DIFF
--- a/database/db_test.go
+++ b/database/db_test.go
@@ -1,0 +1,124 @@
+package database
+
+import (
+	"github.com/icinga/icinga-go-library/config"
+	"github.com/icinga/icinga-go-library/logging"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"testing"
+)
+
+func TestNewDbFromConfig_GetAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+		addr string
+	}{
+		{
+			name: "mysql-simple",
+			conf: &Config{
+				Type:     "mysql",
+				Host:     "example.com",
+				Database: "db",
+				User:     "user",
+			},
+			addr: "mysql://user@example.com:3306/db",
+		},
+		{
+			name: "mysql-custom-port",
+			conf: &Config{
+				Type:     "mysql",
+				Host:     "example.com",
+				Port:     1234,
+				Database: "db",
+				User:     "user",
+			},
+			addr: "mysql://user@example.com:1234/db",
+		},
+		{
+			name: "mysql-tls",
+			conf: &Config{
+				Type:       "mysql",
+				Host:       "example.com",
+				Database:   "db",
+				User:       "user",
+				TlsOptions: config.TLS{Enable: true},
+			},
+			addr: "mysql+tls://user@example.com:3306/db",
+		},
+		{
+			name: "mysql-unix-domain-socket",
+			conf: &Config{
+				Type:     "mysql",
+				Host:     "/var/empty/mysql.sock",
+				Database: "db",
+				User:     "user",
+			},
+			addr: "mysql://user@(/var/empty/mysql.sock)/db",
+		},
+		{
+			name: "pgsql-simple",
+			conf: &Config{
+				Type:     "pgsql",
+				Host:     "example.com",
+				Database: "db",
+				User:     "user",
+			},
+			addr: "pgsql://user@example.com:5432/db",
+		},
+		{
+			name: "pgsql-custom-port",
+			conf: &Config{
+				Type:     "pgsql",
+				Host:     "example.com",
+				Port:     1234,
+				Database: "db",
+				User:     "user",
+			},
+			addr: "pgsql://user@example.com:1234/db",
+		},
+		{
+			name: "pgsql-tls",
+			conf: &Config{
+				Type:       "pgsql",
+				Host:       "example.com",
+				Database:   "db",
+				User:       "user",
+				TlsOptions: config.TLS{Enable: true},
+			},
+			addr: "pgsql+tls://user@example.com:5432/db",
+		},
+		{
+			name: "pgsql-unix-domain-socket",
+			conf: &Config{
+				Type:     "pgsql",
+				Host:     "/var/empty/pgsql",
+				Database: "db",
+				User:     "user",
+			},
+			addr: "pgsql://user@(/var/empty/pgsql/.s.PGSQL.5432)/db",
+		},
+		{
+			name: "pgsql-unix-domain-socket-custom-port",
+			conf: &Config{
+				Type:     "pgsql",
+				Host:     "/var/empty/pgsql",
+				Port:     1234,
+				Database: "db",
+				User:     "user",
+			},
+			addr: "pgsql://user@(/var/empty/pgsql/.s.PGSQL.1234)/db",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := NewDbFromConfig(
+				test.conf,
+				logging.NewLogger(zaptest.NewLogger(t).Sugar(), 0),
+				RetryConnectorCallbacks{})
+			require.NoError(t, err)
+			require.Equal(t, test.addr, db.GetAddr())
+		})
+	}
+}

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -1,0 +1,87 @@
+package redis
+
+import (
+	"github.com/icinga/icinga-go-library/config"
+	"github.com/icinga/icinga-go-library/logging"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"testing"
+)
+
+func TestNewClientFromConfig_GetAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *Config
+		addr string
+	}{
+		{
+			name: "redis-simple",
+			conf: &Config{
+				Host: "example.com",
+			},
+			addr: "redis://example.com:6379",
+		},
+		{
+			name: "redis-custom-port",
+			conf: &Config{
+				Host: "example.com",
+				Port: 6380,
+			},
+			addr: "redis://example.com:6380",
+		},
+		{
+			name: "redis-acl",
+			conf: &Config{
+				Host:     "example.com",
+				Username: "user",
+				Password: "pass",
+			},
+			addr: "redis://user@example.com:6379",
+		},
+		{
+			name: "redis-custom-database",
+			conf: &Config{
+				Host:     "example.com",
+				Database: 23,
+			},
+			addr: "redis://example.com:6379/23",
+		},
+		{
+			name: "redis-tls",
+			conf: &Config{
+				Host:       "example.com",
+				TlsOptions: config.TLS{Enable: true},
+			},
+			addr: "redis+tls://example.com:6379",
+		},
+		{
+			name: "redis-with-everything",
+			conf: &Config{
+				Host:       "example.com",
+				Port:       6380,
+				Username:   "user",
+				Password:   "pass",
+				Database:   23,
+				TlsOptions: config.TLS{Enable: true},
+			},
+			addr: "redis+tls://user@example.com:6380/23",
+		},
+		{
+			name: "redis-unix-domain-socket",
+			conf: &Config{
+				Host: "/var/empty/redis.sock",
+			},
+			addr: "redis://(/var/empty/redis.sock)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			redis, err := NewClientFromConfig(
+				test.conf,
+				logging.NewLogger(zaptest.NewLogger(t).Sugar(), 0))
+			require.NoError(t, err)
+			require.Equal(t, test.addr, redis.GetAddr())
+		})
+	}
+}


### PR DESCRIPTION
The idea of a more informative connection information string was brought up in [#50](https://github.com/Icinga/icinga-go-library/pull/50#pullrequestreview-2213720430). Currently, at least Icinga DB and Icinga Notifications are logging their connection target after startup. This information, however, is quite vague and was now extended to contain, e.g., if TLS is used, the username, the 

```
INFO    icingadb        Connecting to database at 'mysql://icingadb@localhost:3306/icingadb'
INFO    icingadb        Connecting to Redis at 'redis://localhost:6380'
```

Furthermore, the zapcore.ObjectMarshaler interface was implemented, allowing both *db.DB and *redis.Client to be used as a zap logging field, showing the address.