### PR TITLE
Introduce `DB#InsertObtainID()` function

### DIFF
--- a/database/contracts.go
+++ b/database/contracts.go
@@ -1,5 +1,10 @@
 package database
 
+import (
+	"context"
+	"github.com/jmoiron/sqlx"
+)
+
 // Entity is implemented by each type that works with the database package.
 type Entity interface {
 	Fingerprinter
@@ -53,4 +58,11 @@ type Scoper interface {
 type PgsqlOnConflictConstrainter interface {
 	// PgsqlOnConflictConstraint returns the primary or unique key constraint name of the PostgreSQL table.
 	PgsqlOnConflictConstraint() string
+}
+
+// TxOrDB is just a helper interface that can represent a *[sqlx.Tx] or *[DB] instance.
+type TxOrDB interface {
+	sqlx.ExtContext
+
+	PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error)
 }

--- a/database/db.go
+++ b/database/db.go
@@ -836,3 +836,9 @@ func (db *DB) Log(ctx context.Context, query string, counter *com.Counter) perio
 		db.logger.Debugf("Finished executing %q with %d rows in %s", query, counter.Total(), tick.Elapsed)
 	}))
 }
+
+var (
+	// Assert TxOrDB interface compliance of the DB and sqlx.Tx types.
+	_ TxOrDB = (*DB)(nil)
+	_ TxOrDB = (*sqlx.Tx)(nil)
+)


### PR DESCRIPTION
This PR introduces an auxiliary DB function for inserting and retrieving the last inserted ID with both the `PostreSQL` and `MySQL` drivers. Since the MySQL driver supports/provides `LastInsertId()` natively, there's nothing special that this function needs to do. On the other hand, PostgreSQL doesn't provide such functionality on its own, so you have to append a special `RETURNING id` text to the query you want to execute and scan the result into a given dest of your own.

cherry-picked from #18