### PR TITLE
utils: Drop MaxInt

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -73,7 +73,7 @@ func NewClientFromConfig(c *Config, logger *logging.Logger) (*Client, error) {
 
 	client := redis.NewClient(options)
 	options = client.Options()
-	options.PoolSize = utils.MaxInt(32, options.PoolSize)
+	options.PoolSize = max(32, options.PoolSize)
 	options.MaxRetries = options.PoolSize + 1 // https://github.com/go-redis/redis/issues/1737
 
 	return NewClient(redis.NewClient(options), logger, &c.Options), nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -124,15 +124,6 @@ func AppName() string {
 	return filepath.Base(exe)
 }
 
-// MaxInt returns the larger of the given integers.
-func MaxInt(x, y int) int {
-	if x > y {
-		return x
-	}
-
-	return y
-}
-
 // IsUnixAddr indicates whether the given host string represents a Unix socket address.
 //
 // A host string that begins with a forward slash ('/') is considered Unix socket address.


### PR DESCRIPTION
A [generic max function](https://pkg.go.dev/builtin#max) was added to Go in version 1.21, making the `utils.MaxInt` obsolete. Outside, it was not used in neither icingadb, icinga-notifications nor icinga-kubernetes.

```
$ for project in icingadb icinga-notifications icinga-kubernetes; do pushd "$project"; git checkout main; git pull; grep -r "MaxInt"; popd; done
~/git/github.com/Icinga/icingadb ~/git/github.com/Icinga
Already on 'main'
Your branch is up to date with 'origin/main'.
Already up to date.
cmd/icingadb-migrate/cache.go:                          checkpoint = math.MaxInt64 // start from the largest (possible) ID
cmd/icingadb-migrate/main.go:           ht.fromId = math.MaxInt64
grep: icingadb-migrate: binary file matches
grep: icingadb: binary file matches
~/git/github.com/Icinga
~/git/github.com/Icinga/icinga-notifications ~/git/github.com/Icinga
Already on 'main'
Your branch is up to date with 'origin/main'.
Already up to date.
internal/rule/condition.go:const RetryNever = time.Duration(math.MaxInt64)
~/git/github.com/Icinga
~/git/github.com/Icinga/icinga-kubernetes ~/git/github.com/Icinga
Already on 'main'
Your branch is up to date with 'origin/main'.
Already up to date.
pkg/schema/v1/pod.go:           p.CpuLimits = MaxInt(p.CpuLimits, container.Resources.Limits.Cpu().MilliValue())
pkg/schema/v1/pod.go:           p.CpuRequests = MaxInt(p.CpuRequests, container.Resources.Requests.Cpu().MilliValue())
pkg/schema/v1/pod.go:           p.MemoryLimits = MaxInt(p.MemoryLimits, container.Resources.Limits.Memory().MilliValue())
pkg/schema/v1/pod.go:           p.MemoryRequests = MaxInt(p.MemoryRequests, container.Resources.Requests.Memory().MilliValue())
pkg/schema/v1/utils.go:func MaxInt[T constraints.Integer](x, y T) T {
~/git/github.com/Icinga
```