### PR TITLE
retry.WithBackoff: QuickContextExit, Documentation, Tests

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -3,6 +3,7 @@ package retry
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 	"github.com/go-sql-driver/mysql"
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/lib/pq"
@@ -30,61 +31,133 @@ type OnSuccessFunc func(elapsed time.Duration, attempt uint64, lastErr error)
 
 // Settings aggregates optional settings for WithBackoff.
 type Settings struct {
-	// If >0, Timeout lets WithBackoff stop retrying gracefully once elapsed based on the following criteria:
-	// * If the execution of RetryableFunc has taken longer than Timeout, no further attempts are made.
-	// * If Timeout elapses during the sleep phase between retries, one final retry is attempted.
-	// * RetryableFunc is always granted its full execution time and is not canceled if it exceeds Timeout.
+	// Timeout, if > 0, lets WithBackoff stop retrying gracefully once elapsed based on the following criteria:
+	//
+	// 	* If the execution of RetryableFunc has taken longer than Timeout, no further attempts are made.
+	// 	* If Timeout elapses during the sleep phase between retries, one final retry is attempted.
+	// 	* RetryableFunc is always granted its full execution time and is not canceled if it exceeds Timeout unless
+	//	  QuickContextExit is set.
+	//
 	// This means that WithBackoff may not stop exactly after Timeout expires,
 	// or may not retry at all if the first execution of RetryableFunc already takes longer than Timeout.
-	Timeout          time.Duration
+	Timeout time.Duration
+
+	// OnRetryableError, if not nil, is called if a retryable error occurred.
 	OnRetryableError OnRetryableErrorFunc
-	OnSuccess        OnSuccessFunc
+
+	// OnSuccess, if not nil, is called after the function succeeded.
+	OnSuccess OnSuccessFunc
+
+	// QuickContextExit, if set, directly aborts if the context is done and does not wait for functions to finish.
+	//
+	// Technically, all potentially blocking functions - the passed RetryableFunc as well as OnRetryableError and
+	// OnSuccess, if set - are then being executed in another Goroutine via contextBoundFunc. The moment the context
+	// expires, an error is returned while the function continues in its Goroutine, while its return value will be
+	// discarded.
+	QuickContextExit bool
 }
 
-// WithBackoff retries the passed function if it fails and the error allows it to retry.
-// The specified backoff policy is used to determine how long to sleep between attempts.
+// contextBoundFunc wraps an error generating function, but directly exits with an error if the context is done.
+//
+// While the function parameter signature matches RetryableFunc, this is not used here as this function does not only
+// focuses on RetryableFunc, but more generally functions which might get aborted within WithBackoff.
+func contextBoundFunc(f func(context.Context) error) func(context.Context) error {
+	return func(ctx context.Context) error {
+		fResultCh := make(chan error, 1)
+
+		go func() {
+			var err error
+
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("retryable function panicked, %s", r)
+				}
+
+				fResultCh <- err
+			}()
+
+			err = f(ctx)
+		}()
+
+		select {
+		case err := <-fResultCh:
+			return err
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// WithBackoff retries the retryableFunc in case of failure.
+//
+// The passed ctx loosely restricts retries and prohibits retries if the context is done. It is also being passed to the
+// retryableFunc, which MUST honor the context as well. However, unless Settings.QuickContextExit is set, the
+// RetryableFunc blocks the return of the WithBackoff function.
+//
+// If retryableFunc has returned an error, retryable decides based on this error if another attempt should be made. This
+// package comes with the Retryable() function collecting common errors considered recoverable.
+//
+// For debouncing, a delay between a failed run and making another attempt can be defined by backoffFn.
+//
+// Additional configuration and tweaks can be set via settings, as further documented at the Settings type.
 func WithBackoff(
-	ctx context.Context, retryableFunc RetryableFunc, retryable IsRetryable, b backoff.Backoff, settings Settings,
+	ctx context.Context,
+	retryableFunc RetryableFunc,
+	retryable IsRetryable,
+	backoffFn backoff.Backoff,
+	settings Settings,
 ) (err error) {
 	// Channel for retry deadline, which is set to the channel of NewTimer() if a timeout is configured,
 	// otherwise nil, so that it blocks forever if there is no timeout.
 	var timeout <-chan time.Time
-
 	if settings.Timeout > 0 {
 		t := time.NewTimer(settings.Timeout)
 		defer t.Stop()
 		timeout = t.C
 	}
 
+	// funcWrapper is wrapped around potentially time-consuming blocks: the RetryableFunc and, if configured, the two
+	// callback functions. By default, funcWrapper is just a path-through identify function. However, with
+	// Settings.QuickContextExit set, it will be contextBoundFunc, directly bailing out when the context is done.
+	var funcWrapper = func(f func(context.Context) error) func(context.Context) error { return f }
+	if settings.QuickContextExit {
+		funcWrapper = contextBoundFunc
+	}
+
 	start := time.Now()
 	timedOut := false
-	for attempt := uint64(1); ; /* true */ attempt++ {
+	for attempt := uint64(1); ; attempt++ {
 		prevErr := err
 
-		if err = retryableFunc(ctx); err == nil {
-			if settings.OnSuccess != nil {
-				settings.OnSuccess(time.Since(start), attempt, prevErr)
+		err = funcWrapper(func(ctx context.Context) error {
+			err := retryableFunc(ctx)
+			if err == nil {
+				if settings.OnSuccess != nil {
+					settings.OnSuccess(time.Since(start), attempt, prevErr)
+				}
 			}
-
+			return err
+		})(ctx)
+		if err == nil {
 			return
 		}
 
 		// Retryable function may have exited prematurely due to context errors.
 		// We explicitly check the context error here, as the error returned by the retryable function can pass the
-		// error.Is() checks even though it is not a real context error, e.g.
+		// error.Is() checks even though it is not a real context error, for example:
 		// https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/net/net.go;l=422
 		// https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/net/net.go;l=601
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+		if ctx.Err() != nil {
+			err = ctx.Err()
 			if prevErr != nil {
 				err = errors.Wrap(err, prevErr.Error())
 			}
-
 			return
 		}
 
 		if !retryable(err) {
 			err = errors.Wrap(err, "can't retry")
-
 			return
 		}
 
@@ -97,16 +170,18 @@ func WithBackoff(
 
 		if timedOut {
 			err = errors.Wrap(err, "retry deadline exceeded")
-
 			return
 		}
 
 		if settings.OnRetryableError != nil {
-			settings.OnRetryableError(time.Since(start), attempt, err, prevErr)
+			_ = funcWrapper(func(_ context.Context) error {
+				settings.OnRetryableError(time.Since(start), attempt, err, prevErr)
+				return nil
+			})(ctx)
 		}
 
 		select {
-		case <-time.After(b(attempt)):
+		case <-time.After(backoffFn(attempt)):
 		case <-timeout:
 			// Do not stop retrying immediately, but start one last attempt to mitigate timing issues where
 			// the timeout expires while waiting for the next attempt and
@@ -114,7 +189,6 @@ func WithBackoff(
 			timedOut = true
 		case <-ctx.Done():
 			err = errors.Wrap(ctx.Err(), err.Error())
-
 			return
 		}
 	}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,259 @@
+package retry
+
+import (
+	"context"
+	"github.com/icinga/icinga-go-library/backoff"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestWithBackoff_Trivial tests a static function returning a non-error.
+func TestWithBackoff_Trivial(t *testing.T) {
+	require.NoError(t,
+		WithBackoff(
+			context.Background(),
+			func(_ context.Context) error { return nil },
+			func(_ error) bool { return false },
+			func(_ uint64) time.Duration { return 0 },
+			Settings{}))
+}
+
+// TestWithBackoff_NotRetryable tests a static function retuning an error, marked as non-retryable.
+func TestWithBackoff_NotRetryable(t *testing.T) {
+	err := WithBackoff(
+		context.Background(),
+		func(_ context.Context) error { return io.EOF },
+		func(_ error) bool { return false },
+		func(_ uint64) time.Duration { return 0 },
+		Settings{})
+
+	require.ErrorAs(t, err, &io.EOF)
+	require.ErrorContains(t, err, "can't retry")
+}
+
+// TestWithBackoff_Panic tests a panicking function, expecting to receive the panic.
+func TestWithBackoff_Panic(t *testing.T) {
+	require.Panics(t, func() {
+		_ = WithBackoff(
+			context.Background(),
+			func(_ context.Context) error { panic(":<") },
+			func(_ error) bool { return false },
+			func(_ uint64) time.Duration { return 0 },
+			Settings{})
+	})
+}
+
+// TestWithBackoff_SimpleRetry tests retrying a function which returns a retryable error only the first time.
+func TestWithBackoff_SimpleRetry(t *testing.T) {
+	isReady := false
+
+	require.NoError(t,
+		WithBackoff(
+			context.Background(),
+			func(_ context.Context) error {
+				if !isReady {
+					isReady = true
+					return io.EOF
+				}
+				return nil
+			},
+			Retryable,
+			func(_ uint64) time.Duration { return 0 },
+			Settings{}))
+}
+
+// TestWithBackoff_ContextDone tests a static function returning a retryable error until the context has timed out.
+func TestWithBackoff_ContextDone(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	require.ErrorAs(t,
+		WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return io.EOF
+			},
+			Retryable,
+			backoff.NewExponentialWithJitter(time.Millisecond, 10*time.Millisecond),
+			Settings{}),
+		&context.DeadlineExceeded)
+}
+
+// TestWithBackoff_ContextDoneBlockingFunc tests a static function returning a retryable error after sleeping a bit
+// until the context has timed out. As the backoff has no delay, all blocking is performed in the RetryableFunc,
+// resulting to exit in the context error check after the function call and not in the final select.
+func TestWithBackoff_ContextDoneBlockingFunc(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	require.ErrorAs(t,
+		WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				time.Sleep(10 * time.Millisecond)
+				return io.EOF
+			},
+			Retryable,
+			func(_ uint64) time.Duration { return 0 },
+			Settings{}),
+		&context.DeadlineExceeded)
+}
+
+// TestWithBackoff_TimeoutEventuallyOk tests a function returning a non-error after being called elven times while using
+// a Settings.Timeout.
+func TestWithBackoff_TimeoutEventuallyOk(t *testing.T) {
+	readyCountdown := 10
+
+	require.NoError(t,
+		WithBackoff(
+			context.Background(),
+			func(_ context.Context) error {
+				if readyCountdown > 0 {
+					readyCountdown--
+					return io.EOF
+				}
+				return nil
+			},
+			Retryable,
+			backoff.NewExponentialWithJitter(time.Millisecond, 10*time.Millisecond),
+			Settings{Timeout: 500 * time.Millisecond}))
+}
+
+// TestWithBackoff_TimeoutFail tests a static function returning an error while using a Settings.Timeout, expecting to
+// eventually hit this timeout.
+func TestWithBackoff_TimeoutFail(t *testing.T) {
+	err := WithBackoff(
+		context.Background(),
+		func(_ context.Context) error { return io.EOF },
+		Retryable,
+		backoff.NewExponentialWithJitter(time.Millisecond, 10*time.Millisecond),
+		Settings{Timeout: 500 * time.Millisecond})
+
+	require.ErrorAs(t, err, &io.EOF)
+	require.ErrorContains(t, err, "retry deadline exceeded")
+}
+
+// TestWithBackoff_TimeoutBlockingFunc tests a static function returning an error after blocking for quite some time
+// while using a Settings.Timeout and having a zero backoff duration. Compared to the previous test,
+// TestWithBackoff_TimeoutFail, this will not result in a re-run of the RetryableFunc.
+func TestWithBackoff_TimeoutBlockingFunc(t *testing.T) {
+	err := WithBackoff(
+		context.Background(),
+		func(_ context.Context) error {
+			time.Sleep(10 * time.Millisecond)
+			return io.EOF
+		},
+		Retryable,
+		func(_ uint64) time.Duration { return 0 },
+		Settings{Timeout: 500 * time.Millisecond})
+
+	require.ErrorAs(t, err, &io.EOF)
+	require.ErrorContains(t, err, "retry deadline exceeded")
+}
+
+// TestWithBackoff_Callback tests a function returning a non-error after being called elven times while having both a
+// Settings.OnRetryableError and a Settings.OnSuccess defined.
+func TestWithBackoff_Callback(t *testing.T) {
+	readyCountdown := 10
+	errorCallbackCounter := uint64(0)
+	successCallbackCounter := uint64(0)
+
+	require.NoError(t,
+		WithBackoff(
+			context.Background(),
+			func(_ context.Context) error {
+				if readyCountdown > 0 {
+					readyCountdown--
+					return io.EOF
+				}
+				return nil
+			},
+			Retryable,
+			func(_ uint64) time.Duration { return 0 },
+			Settings{
+				OnRetryableError: func(_ time.Duration, c uint64, _, _ error) { errorCallbackCounter = c },
+				OnSuccess:        func(_ time.Duration, c uint64, _ error) { successCallbackCounter = c },
+			}))
+
+	require.Equal(t, uint64(10), errorCallbackCounter, "last OnRetryableError attempt")
+	require.Equal(t, uint64(11), successCallbackCounter, "OnSuccess attempt")
+}
+
+// TestWithBackoff_QuickContextExit tests retrying a function which returns a retryable error only the first time while
+// having Settings.QuickContextExit defined. However, the backoff is a magnitude smaller than the context timeout.
+func TestWithBackoff_QuickContextExit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	isReady := false
+
+	require.NoError(t,
+		WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				if !isReady {
+					isReady = true
+					return io.EOF
+				}
+				return nil
+			},
+			Retryable,
+			backoff.NewExponentialWithJitter(time.Millisecond, 10*time.Millisecond),
+			Settings{QuickContextExit: true}))
+}
+
+// TestWithBackoff_QuickContextExitPanic tests a panicking function while having Settings.QuickContextExit defined. It
+// is expected to be recovered and returned as an error.
+func TestWithBackoff_QuickContextExitPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	require.ErrorContains(t,
+		WithBackoff(
+			ctx,
+			func(_ context.Context) error { panic(":<") },
+			Retryable,
+			backoff.NewExponentialWithJitter(time.Millisecond, 10*time.Millisecond),
+			Settings{QuickContextExit: true}),
+		"retryable function panicked, :<")
+}
+
+// TestWithBackoff_QuickContextExitTimeout tests a static function returning no error after blocking for an eternity
+// while having Settings.QuickContextExit defined. The context exceeds ages before the RetryableFunc.
+func TestWithBackoff_QuickContextExitTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- WithBackoff(
+			ctx,
+			func(_ context.Context) error {
+				time.Sleep(time.Second)
+				return nil
+			},
+			Retryable,
+			func(_ uint64) time.Duration { return 0 },
+			Settings{QuickContextExit: true})
+		close(errCh)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorAs(t, err, &context.DeadlineExceeded)
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "timeout, context is long gone")
+	}
+}


### PR DESCRIPTION
The retry.WithBackoff function only loosely respected the provided context. In particular, the RetryableFunc could survive the context termination and block as long as it desires.

For situations where timing is critical and a deadline bound context is used, this behavior might be undesirable. That's why the new Settings.QuickContextExit option has been introduced, which effectively wraps time-consuming, blocking functions with an additional context check and bails out directly when the context is done.

This change was reflected in the documentation, which was generally extended, trying to explain more about the implementation details.

While working on the function, some minor refactorings were done. Notable is the simplified check if the context has finished.

Finally, tests were written for retry.WithBackoff to verify the expected behavior and ease future changes.