### PR TITLE
database: Deferred Transaction Rollback

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -574,6 +574,7 @@ func (db *DB) NamedBulkExecTx(
 								if err != nil {
 									return errors.Wrap(err, "can't start transaction")
 								}
+								defer func() { _ = tx.Rollback() }()
 
 								stmt, err := tx.PrepareNamedContext(ctx, query)
 								if err != nil {


### PR DESCRIPTION
In case of an error before committing the database transaction, the function exits but does not rollback the transaction. By adding a deferred rollback, it will be executed or a no-op if a commit succeeded.