### PR TITLE
Test `config`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,12 +1,265 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"io/fs"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 )
+
+// errInvalidConfiguration is an error that indicates invalid configuration.
+var errInvalidConfiguration = errors.New("invalid configuration")
+
+// validateValid is a struct used to represent a valid configuration.
+type validateValid struct{}
+
+// Validate returns nil indicating the configuration is valid.
+func (_ *validateValid) Validate() error {
+	return nil
+}
+
+// validateInvalid is a struct used to represent an invalid configuration.
+type validateInvalid struct{}
+
+// Validate returns errInvalidConfiguration indicating the configuration is invalid.
+func (_ *validateInvalid) Validate() error {
+	return errInvalidConfiguration
+}
+
+// simpleConfig is an always valid test configuration struct with only one key.
+type simpleConfig struct {
+	Key string `yaml:"key"`
+	validateValid
+}
+
+// inlinedConfigPart is a part of a test configuration that will be inlined.
+type inlinedConfigPart struct {
+	Key string `yaml:"inlined-key"`
+}
+
+// inlinedConfig is an always valid test configuration struct with a key and an inlined part from inlinedConfigPart.
+type inlinedConfig struct {
+	Key     string            `yaml:"key"`
+	Inlined inlinedConfigPart `yaml:",inline"`
+	validateValid
+}
+
+// embeddedConfigPart is a part of a test configuration that will be embedded.
+type embeddedConfigPart struct {
+	Key string `yaml:"embedded-key"`
+}
+
+// embeddedConfig is an always valid test configuration struct with a key and an embedded part from embeddedConfigPart.
+type embeddedConfig struct {
+	Key      string             `yaml:"key"`
+	Embedded embeddedConfigPart `yaml:"embedded"`
+	validateValid
+}
+
+// defaultConfigPart is a part of a test configuration that defines a default value.
+type defaultConfigPart struct {
+	Key string `yaml:"default-key" default:"default-value"`
+}
+
+// defaultConfig is an always valid test configuration struct with a key and
+// an inlined part with defaults from defaultConfigPart.
+type defaultConfig struct {
+	Key     string            `yaml:"key"`
+	Default defaultConfigPart `yaml:",inline"`
+	validateValid
+}
+
+// invalidConfig is an always invalid test configuration struct with only one key.
+type invalidConfig struct {
+	Key string `yaml:"key"`
+	validateInvalid
+}
+
+// configWithInvalidDefault is a test configuration struct used to verify error propagation from defaults.Set().
+// It intentionally defines an invalid default value for a map,
+// which the defaults package parses using json.Unmarshal().
+// The test then asserts that a json.SyntaxError is returned.
+// This approach is necessary because the defaults package does not return errors for parsing scalar types,
+// which was quite unexpected when writing the test.
+type configWithInvalidDefault struct {
+	Key                string      `yaml:"key"`
+	InvalidDefaultJson map[any]any `yaml:"valid" default:"a"`
+	validateValid
+}
+
+func TestFromYAMLFile(t *testing.T) {
+	type yamlTestCase struct {
+		// Test case name.
+		name string
+		// Content of the YAML file.
+		content string
+		// Expected configuration. Empty if parsing the content is expected to produce an error.
+		expected Validator
+		// Indicates if the configuration is expected to be invalid (by returning errInvalidConfiguration).
+		invalid bool
+	}
+
+	yamlTests := []yamlTestCase{
+		{
+			name:    "Simple YAML",
+			content: `key: value`,
+			expected: &simpleConfig{
+				Key: "value",
+			},
+		},
+		{
+			name: "Inlined YAML",
+			content: `
+key: value
+inlined-key: inlined-value`,
+			expected: &inlinedConfig{
+				Key:     "value",
+				Inlined: inlinedConfigPart{Key: "inlined-value"},
+			},
+		},
+		{
+			name: "Embedded YAML",
+			content: `
+key: value
+embedded:
+  embedded-key: embedded-value`,
+			expected: &embeddedConfig{
+				Key:      "value",
+				Embedded: embeddedConfigPart{Key: "embedded-value"},
+			},
+		},
+		{
+			name:    "Defaults",
+			content: `key: value`,
+			expected: &defaultConfig{
+				Key:     "value",
+				Default: defaultConfigPart{Key: "default-value"},
+			},
+		},
+		{
+			name: "Overriding Defaults",
+			content: `
+key: value
+default-key: overridden-value`,
+			expected: &defaultConfig{
+				Key:     "value",
+				Default: defaultConfigPart{Key: "overridden-value"},
+			},
+		},
+		{
+			name:    "Empty YAML",
+			content: "",
+		},
+		{
+			name:    "Empty YAML with directive separator",
+			content: `---`,
+		},
+		{
+			name:    "Faulty YAML",
+			content: `:\n`,
+		},
+		{
+			name:    "Invalid YAML",
+			content: `key: value`,
+			expected: &invalidConfig{
+				Key: "value",
+			},
+			invalid: true,
+		},
+	}
+
+	for _, tc := range yamlTests {
+		t.Run(tc.name, func(t *testing.T) {
+			yamlFile, err := os.CreateTemp("", "*.yaml")
+			require.NoError(t, err)
+
+			defer func(name string) {
+				_ = os.Remove(name)
+			}(yamlFile.Name())
+
+			require.NoError(t, os.WriteFile(yamlFile.Name(), []byte(tc.content), 0600))
+
+			if tc.expected != nil {
+				// Since our test cases only define the expected configuration,
+				// we need to create a new instance of that type for FromYAMLFile to parse the configuration into.
+				actual := reflect.New(reflect.TypeOf(tc.expected).Elem()).Interface().(Validator)
+				err := FromYAMLFile(yamlFile.Name(), actual)
+				if !tc.invalid {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, errInvalidConfiguration)
+				}
+
+				require.Equal(t, tc.expected, actual)
+			} else {
+				err := FromYAMLFile(yamlFile.Name(), &validateValid{})
+				require.Error(t, err)
+				// Assert that error is a parsing error.
+				require.NotErrorIs(t, err, ErrInvalidArgument)
+				require.NotErrorIs(t, err, errInvalidConfiguration)
+			}
+		})
+	}
+
+	t.Run("Error propagation from defaults.Set()", func(t *testing.T) {
+		var config configWithInvalidDefault
+		var syntaxError *json.SyntaxError
+
+		yamlFile, err := os.CreateTemp("", "*.yaml")
+		require.NoError(t, err)
+		require.NoError(t, yamlFile.Close())
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(yamlFile.Name())
+
+		require.NoError(t, os.WriteFile(yamlFile.Name(), []byte(`key: value`), 0600))
+
+		err = FromYAMLFile(yamlFile.Name(), &config)
+		require.ErrorAs(t, err, &syntaxError)
+	})
+
+	t.Run("Nil pointer argument", func(t *testing.T) {
+		var config *struct{ Validator }
+
+		err := FromYAMLFile("", config)
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Nil argument", func(t *testing.T) {
+		err := FromYAMLFile("", nil)
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Non-existent file", func(t *testing.T) {
+		var config struct{ validateValid }
+		var pathError *fs.PathError
+
+		err := FromYAMLFile("nonexistent.yaml", &config)
+		require.ErrorAs(t, err, &pathError)
+		require.ErrorIs(t, pathError.Err, fs.ErrNotExist)
+	})
+
+	t.Run("Permission denied", func(t *testing.T) {
+		var config struct{ validateValid }
+		var pathError *fs.PathError
+
+		yamlFile, err := os.CreateTemp("", "*.yaml")
+		require.NoError(t, err)
+		require.NoError(t, yamlFile.Chmod(0000))
+		require.NoError(t, yamlFile.Close())
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(yamlFile.Name())
+
+		err = FromYAMLFile(yamlFile.Name(), &config)
+		require.ErrorAs(t, err, &pathError)
+	})
+}
 
 func TestParseFlags(t *testing.T) {
 	t.Run("Simple flags", func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestParseFlags(t *testing.T) {
+	t.Run("Simple flags", func(t *testing.T) {
+		originalArgs := os.Args
+		defer func() {
+			os.Args = originalArgs
+		}()
+
+		os.Args = []string{"cmd", "--test-flag=value"}
+
+		type Flags struct {
+			TestFlag string `long:"test-flag"`
+		}
+
+		var flags Flags
+		err := ParseFlags(&flags)
+		require.NoError(t, err)
+		require.Equal(t, "value", flags.TestFlag)
+	})
+
+	t.Run("Nil pointer argument", func(t *testing.T) {
+		var flags *any
+
+		err := ParseFlags(flags)
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Nil argument", func(t *testing.T) {
+		err := ParseFlags(nil)
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Exit on help flag", func(t *testing.T) {
+		// This test case checks the behavior of ParseFlags() when the help flag (e.g. -h) is provided.
+		// Since ParseFlags() calls os.Exit() upon encountering the help flag, we need to run this
+		// test in a separate subprocess to capture and verify the output without terminating the
+		// main test process.
+		if os.Getenv("TEST_HELP_FLAG") == "1" {
+			// This block runs in the subprocess.
+			type Flags struct{}
+			var flags Flags
+
+			originalArgs := os.Args
+			defer func() {
+				os.Args = originalArgs
+			}()
+
+			os.Args = []string{"cmd", "-h"}
+
+			if err := ParseFlags(&flags); err != nil {
+				panic(err)
+			}
+
+			return
+		}
+
+		// This block runs in the main test process. It starts this test again in a subprocess with the
+		// TEST_HELP_FLAG=1 environment variable provided in order to run the above code block.
+		// #nosec G204 -- The subprocess is launched with controlled input for testing purposes.
+		// The command and arguments are derived from the test framework and are not influenced by external input.
+		cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+		cmd.Env = append(os.Environ(), "TEST_HELP_FLAG=1")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+		// When the help flag is provided, ParseFlags() outputs usage information,
+		// including "-h, --help Show this help message" (whitespace may vary).
+		require.Contains(t, string(out), "-h, --help")
+	})
+}

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestTLS_MakeConfig(t *testing.T) {
+	t.Run("TLS disabled", func(t *testing.T) {
+		tlsConfig := &TLS{Enable: false}
+		config, err := tlsConfig.MakeConfig("icinga.com")
+		require.NoError(t, err)
+		require.Nil(t, config)
+	})
+
+	t.Run("Server name", func(t *testing.T) {
+		tlsConfig := &TLS{Enable: true}
+		config, err := tlsConfig.MakeConfig("icinga.com")
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.Equal(t, "icinga.com", config.ServerName)
+	})
+
+	t.Run("Empty server name", func(t *testing.T) {
+		t.Skip("TODO: Either ServerName or InsecureSkipVerify must be specified in the tls.Config and" +
+			" should be verified in MakeConfig.")
+	})
+
+	t.Run("Insecure skip verify", func(t *testing.T) {
+		tlsConfig := &TLS{Enable: true, Insecure: true}
+		config, err := tlsConfig.MakeConfig("icinga.com")
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.True(t, config.InsecureSkipVerify)
+	})
+
+	t.Run("Missing client certificate", func(t *testing.T) {
+		tlsConfig := &TLS{Enable: true, Key: "test.key"}
+		_, err := tlsConfig.MakeConfig("icinga.com")
+		require.Error(t, err)
+	})
+
+	t.Run("Missing private key", func(t *testing.T) {
+		tlsConfig := &TLS{Enable: true, Cert: "test.crt"}
+		_, err := tlsConfig.MakeConfig("icinga.com")
+		require.Error(t, err)
+	})
+
+	t.Run("x509", func(t *testing.T) {
+		cert, key, err := generateCert("cert", generateCertOptions{})
+		require.NoError(t, err)
+		certFile, err := os.CreateTemp("", "cert-*.pem")
+		require.NoError(t, err)
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(certFile.Name())
+		err = pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		require.NoError(t, err)
+
+		keyFile, err := os.CreateTemp("", "key-*.pem")
+		require.NoError(t, err)
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(keyFile.Name())
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+		require.NoError(t, err)
+		err = pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+		require.NoError(t, err)
+
+		ca, _, err := generateCert("ca", generateCertOptions{ca: true})
+		require.NoError(t, err)
+		caFile, err := os.CreateTemp("", "ca-*.pem")
+		require.NoError(t, err)
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(caFile.Name())
+		err = pem.Encode(caFile, &pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw})
+		require.NoError(t, err)
+
+		corruptFile, err := os.CreateTemp("", "corrupt-*.pem")
+		require.NoError(t, err)
+		defer func(name string) {
+			_ = os.Remove(name)
+		}(corruptFile.Name())
+		err = os.WriteFile(corruptFile.Name(), []byte("corrupt PEM"), 0600)
+		require.NoError(t, err)
+
+		t.Run("Valid certificate and key", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: keyFile.Name()}
+			config, err := tlsConfig.MakeConfig("icinga.com")
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			require.Len(t, config.Certificates, 1)
+		})
+
+		t.Run("Mismatched certificate and key", func(t *testing.T) {
+			_key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			_keyFile, err := os.CreateTemp("", "key-*.pem")
+			require.NoError(t, err)
+			defer func(name string) {
+				_ = os.Remove(name)
+			}(_keyFile.Name())
+			_keyBytes, err := x509.MarshalPKCS8PrivateKey(_key)
+			require.NoError(t, err)
+			err = pem.Encode(_keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: _keyBytes})
+			require.NoError(t, err)
+
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: _keyFile.Name()}
+			_, err = tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Invalid certificate path", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Cert: "nonexistent.crt", Key: keyFile.Name()}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Invalid certificate permissions", func(t *testing.T) {
+			fileInfo, err := certFile.Stat()
+			require.NoError(t, err)
+			defer func() {
+				err := certFile.Chmod(fileInfo.Mode())
+				require.NoError(t, err)
+			}()
+			err = certFile.Chmod(0000)
+			require.NoError(t, err)
+
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: keyFile.Name()}
+			_, err = tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Corrupt certificate", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Cert: corruptFile.Name(), Key: keyFile.Name()}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Invalid key path", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: "nonexistent.key"}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Invalid key permissions", func(t *testing.T) {
+			fileInfo, err := keyFile.Stat()
+			require.NoError(t, err)
+			defer func() {
+				err := keyFile.Chmod(fileInfo.Mode())
+				require.NoError(t, err)
+			}()
+			err = keyFile.Chmod(0000)
+			require.NoError(t, err)
+
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: keyFile.Name()}
+			_, err = tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Corrupt key", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Cert: certFile.Name(), Key: corruptFile.Name()}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Valid CA", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Ca: caFile.Name()}
+			config, err := tlsConfig.MakeConfig("icinga.com")
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			require.NotNil(t, config.RootCAs)
+		})
+
+		t.Run("Invalid CA path", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Ca: "nonexistent.ca"}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Invalid CA permissions", func(t *testing.T) {
+			fileInfo, err := caFile.Stat()
+			require.NoError(t, err)
+			defer func() {
+				err := caFile.Chmod(fileInfo.Mode())
+				require.NoError(t, err)
+			}()
+			err = caFile.Chmod(0000)
+			require.NoError(t, err)
+
+			tlsConfig := &TLS{Enable: true, Ca: caFile.Name()}
+			_, err = tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+
+		t.Run("Corrupt CA", func(t *testing.T) {
+			tlsConfig := &TLS{Enable: true, Ca: corruptFile.Name()}
+			_, err := tlsConfig.MakeConfig("icinga.com")
+			require.Error(t, err)
+		})
+	})
+}
+
+type generateCertOptions struct {
+	ca        bool
+	issuer    *x509.Certificate
+	issuerKey crypto.PrivateKey
+}
+
+func generateCert(cn string, options generateCertOptions) (*x509.Certificate, crypto.PrivateKey, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  options.ca,
+	}
+
+	var issuer *x509.Certificate
+	var issuerKey crypto.PrivateKey
+	if options.issuer != nil {
+		if options.issuerKey == nil {
+			return nil, nil, errors.New("issuerKey required if issuer set")
+		}
+		issuer = options.issuer
+		issuerKey = options.issuerKey
+	} else {
+		issuer = template
+		issuerKey = privateKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, issuer, privateKey.Public(), issuerKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, privateKey, nil
+}


### PR DESCRIPTION
This PR introduces tests for the `ParseFlags()`, `FromYAMLFile()` and `TLS.MakeConfig()` functions:

## ParseFlags

* Verifies that command-line flags are correctly parsed into a struct.
* Error propagation from defaults.Set().
* **Nil pointer argument**: Tests calling FromYAMLFile with a nil pointer argument.
* **Nil argument**: Tests calling FromYAMLFile with a nil argument.

## FromYAMLFile

* **Simple YAML**: Tests parsing a simple YAML file.
* **Inlined YAML**: Tests parsing a YAML file with inlined fields.
* **Embedded YAML**: Tests parsing a YAML file with embedded fields.
* **Defaults**: Tests parsing a YAML file with default values.
* **Overriding defaults**: Tests parsing a YAML file overriding default values.
* **Empty YAML**: Tests parsing an empty YAML file.
* **Empty YAML with directive separator**: Tests parsing an empty YAML file with a directive separator.
* **Faulty YAML**: Tests parsing a faulty YAML file.
* **Invalid YAML**: Tests parsing a YAML file that is expected to fail validation.
* **Nil pointer argument**: Tests calling FromYAMLFile with a nil pointer argument.
* **Nil argument**: Tests calling FromYAMLFile with a nil argument.
* **Non-existent file**: Tests calling FromYAMLFile with a non-existent file.
* **Permission denied**: Tests calling FromYAMLFile with a file that has no read permissions.

## TLS.MakeConfig()

1. **Basic Configuration**
    * Verifies that the function returns `nil` when TLS is disabled.
    * Ensures the server name is correctly set in the TLS configuration.
    * Checks that `InsecureSkipVerify` is set to `true` when specified.
    * Ensures an error is returned when the client certificate is missing.
    * Ensures an error is returned when the private key is missing.

2. **x509 Certificate Handling**
    * **Valid certificate and key**: Verifies successful configuration with valid certificate and key.
    * **Mismatched certificate and key**: Ensures an error is returned for mismatched certificate and key.
    * **Invalid certificate path**: Ensures an error is returned for a non-existent certificate file.
    * **Invalid certificate permissions**: Ensures an error is returned for a certificate file with no read permissions.
    * **Corrupt certificate**: Ensures an error is returned for a corrupt certificate file.
    * **Invalid key path**: Ensures an error is returned for a non-existent key file.
    * **Invalid key permissions**: Ensures an error is returned for a key file with no read permissions.
    * **Corrupt key**: Ensures an error is returned for a corrupt key file.
    * **Valid CA**: Verifies successful configuration with a valid CA certificate.
    * **Invalid CA path**: Ensures an error is returned for a non-existent CA file.
    * **Invalid CA permissions**: Ensures an error is returned for a CA file with no read permissions.
    * **Corrupt CA**: Ensures an error is returned for a corrupt CA file.