### PR TITLE
objectpacker: Assure gosec that in.Len() to uint64 cannot overflow

### DIFF
--- a/objectpacker/objectpacker.go
+++ b/objectpacker/objectpacker.go
@@ -88,6 +88,7 @@ func packValue(in reflect.Value, out io.Writer) error {
 		}
 
 		l := in.Len()
+		// #nosec G115 -- in.Len() is a non-negative number, thus cannot overflow for conversion to uint64
 		if err := binary.Write(out, binary.BigEndian, uint64(l)); err != nil {
 			return err
 		}
@@ -118,6 +119,7 @@ func packValue(in reflect.Value, out io.Writer) error {
 		}
 
 		l := in.Len()
+		// #nosec G115 -- in.Len() is a non-negative number, thus cannot overflow for conversion to uint64
 		if err := binary.Write(out, binary.BigEndian, uint64(l)); err != nil {
 			return err
 		}


### PR DESCRIPTION
> objectpacker/objectpacker.go:91:55: G115: integer overflow conversion int -> uint64 (gosec)
>                 if err := binary.Write(out, binary.BigEndian, uint64(l)); err != nil {