### PR TITLE
Test everything related to config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -308,16 +308,14 @@ func TestFromYAMLFile(t *testing.T) {
 	})
 
 	t.Run("Non-existent file", func(t *testing.T) {
-		var config struct{ validateValid }
 		var pathError *fs.PathError
 
-		err := FromYAMLFile("nonexistent.yaml", &config)
+		err := FromYAMLFile("nonexistent.yaml", &validateValid{})
 		require.ErrorAs(t, err, &pathError)
 		require.ErrorIs(t, pathError.Err, fs.ErrNotExist)
 	})
 
 	t.Run("Permission denied", func(t *testing.T) {
-		var config struct{ validateValid }
 		var pathError *fs.PathError
 
 		yamlFile, err := os.CreateTemp("", "*.yaml")
@@ -328,7 +326,7 @@ func TestFromYAMLFile(t *testing.T) {
 			_ = os.Remove(name)
 		}(yamlFile.Name())
 
-		err = FromYAMLFile(yamlFile.Name(), &config)
+		err = FromYAMLFile(yamlFile.Name(), &validateValid{})
 		require.ErrorAs(t, err, &pathError)
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/icinga/icinga-go-library/testutils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"io/fs"
@@ -33,50 +34,50 @@ func (_ *validateInvalid) Validate() error {
 
 // simpleConfig is an always valid test configuration struct with only one key.
 type simpleConfig struct {
-	Key string `yaml:"key"`
+	Key string `yaml:"key" env:"KEY"`
 	validateValid
 }
 
 // inlinedConfigPart is a part of a test configuration that will be inlined.
 type inlinedConfigPart struct {
-	Key string `yaml:"inlined-key"`
+	Key string `yaml:"inlined-key" env:"INLINED_KEY"`
 }
 
 // inlinedConfig is an always valid test configuration struct with a key and an inlined part from inlinedConfigPart.
 type inlinedConfig struct {
-	Key     string            `yaml:"key"`
+	Key     string            `yaml:"key" env:"KEY"`
 	Inlined inlinedConfigPart `yaml:",inline"`
 	validateValid
 }
 
 // embeddedConfigPart is a part of a test configuration that will be embedded.
 type embeddedConfigPart struct {
-	Key string `yaml:"embedded-key"`
+	Key string `yaml:"embedded-key" env:"EMBEDDED_KEY"`
 }
 
 // embeddedConfig is an always valid test configuration struct with a key and an embedded part from embeddedConfigPart.
 type embeddedConfig struct {
-	Key      string             `yaml:"key"`
-	Embedded embeddedConfigPart `yaml:"embedded"`
+	Key      string             `yaml:"key" env:"KEY"`
+	Embedded embeddedConfigPart `yaml:"embedded" envPrefix:"EMBEDDED_"`
 	validateValid
 }
 
 // defaultConfigPart is a part of a test configuration that defines a default value.
 type defaultConfigPart struct {
-	Key string `yaml:"default-key" default:"default-value"`
+	Key string `yaml:"default-key" env:"DEFAULT_KEY" default:"default-value"`
 }
 
 // defaultConfig is an always valid test configuration struct with a key and
 // an inlined part with defaults from defaultConfigPart.
 type defaultConfig struct {
-	Key     string            `yaml:"key"`
+	Key     string            `yaml:"key"  env:"KEY"`
 	Default defaultConfigPart `yaml:",inline"`
 	validateValid
 }
 
 // invalidConfig is an always invalid test configuration struct with only one key.
 type invalidConfig struct {
-	Key string `yaml:"key"`
+	Key string `yaml:"key" env:"KEY"`
 	validateInvalid
 }
 
@@ -87,70 +88,169 @@ type invalidConfig struct {
 // This approach is necessary because the defaults package does not return errors for parsing scalar types,
 // which was quite unexpected when writing the test.
 type configWithInvalidDefault struct {
-	Key                string      `yaml:"key"`
-	InvalidDefaultJson map[any]any `yaml:"valid" default:"a"`
+	Key                string      `yaml:"key" env:"KEY"`
+	InvalidDefaultJson map[any]any `yaml:"invalid" envPrefix:"INVALID_" default:"a"`
 	validateValid
 }
 
+// nonStructValidator is a non-struct type that implements the Validator interface but
+// cannot be used in FromEnv and FromYAMLFile to parse configuration into.
+type nonStructValidator int
+
+func (nonStructValidator) Validate() error {
+	return nil
+}
+
+// configTests specifies common test cases for the FromEnv and FromYAMLFile functions.
+var configTests = []testutils.TestCase[Validator, testutils.ConfigTestData]{
+	{
+		Name: "Simple Config",
+		Data: testutils.ConfigTestData{
+			Yaml: `key: value`,
+			Env:  map[string]string{"KEY": "value"},
+		},
+		Expected: &simpleConfig{
+			Key: "value",
+		},
+	},
+	{
+		Name: "Inlined Config",
+		Data: testutils.ConfigTestData{
+			Yaml: `
+key: value
+inlined-key: inlined-value`,
+			Env: map[string]string{
+				"KEY":         "value",
+				"INLINED_KEY": "inlined-value",
+			}},
+		Expected: &inlinedConfig{
+			Key:     "value",
+			Inlined: inlinedConfigPart{Key: "inlined-value"},
+		},
+	},
+	{
+		Name: "Embedded Config",
+		Data: testutils.ConfigTestData{
+			Yaml: `
+key: value
+embedded:
+  embedded-key: embedded-value`,
+			Env: map[string]string{
+				"KEY":                   "value",
+				"EMBEDDED_EMBEDDED_KEY": "embedded-value",
+			}},
+		Expected: &embeddedConfig{
+			Key:      "value",
+			Embedded: embeddedConfigPart{Key: "embedded-value"},
+		},
+	},
+	{
+		Name: "Defaults",
+		Data: testutils.ConfigTestData{
+			Yaml: `key: value`,
+			Env:  map[string]string{"KEY": "value"}},
+		Expected: &defaultConfig{
+			Key:     "value",
+			Default: defaultConfigPart{Key: "default-value"},
+		},
+	},
+	{
+		Name: "Overriding Defaults",
+		Data: testutils.ConfigTestData{
+			Yaml: `
+key: value
+default-key: overridden-value`,
+			Env: map[string]string{
+				"KEY":         "value",
+				"DEFAULT_KEY": "overridden-value",
+			}},
+		Expected: &defaultConfig{
+			Key:     "value",
+			Default: defaultConfigPart{Key: "overridden-value"},
+		},
+	},
+	{
+		Name: "Validate invalid",
+		Data: testutils.ConfigTestData{
+			Yaml: `key: value`,
+			Env:  map[string]string{"KEY": "value"},
+		},
+		Expected: &invalidConfig{
+			Key: "value",
+		},
+		Error: testutils.ErrorIs(errInvalidConfiguration),
+	},
+	{
+		Name: "Error propagation from defaults.Set()",
+		Data: testutils.ConfigTestData{
+			Yaml: `key: value`,
+			Env:  map[string]string{"KEY": "value"},
+		},
+		Expected: &configWithInvalidDefault{},
+		Error:    testutils.ErrorAs[*json.SyntaxError](),
+	},
+}
+
+func TestFromEnv(t *testing.T) {
+	for _, tc := range configTests {
+		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
+			// Since our test cases only define the expected configuration,
+			// we need to create a new instance of that type for FromEnv to parse the configuration into.
+			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+
+			err := FromEnv(actual, EnvOptions{Environment: data.Env})
+
+			return actual, err
+		}))
+	}
+
+	t.Run("Nil pointer argument", func(t *testing.T) {
+		var config *struct{ Validator }
+
+		err := FromEnv(config, EnvOptions{})
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Nil argument", func(t *testing.T) {
+		err := FromEnv(nil, EnvOptions{})
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Non-struct pointer argument", func(t *testing.T) {
+		var config nonStructValidator
+
+		err := FromEnv(&config, EnvOptions{})
+		// Struct pointer assertion is done in the defaults library,
+		// so we must ensure that the error returned is not one of our own errors.
+		require.NotErrorIs(t, err, ErrInvalidArgument)
+		require.NotErrorIs(t, err, errInvalidConfiguration)
+	})
+}
+
 func TestFromYAMLFile(t *testing.T) {
-	type yamlTestCase struct {
+	for _, tc := range configTests {
+		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
+			// Since our test cases only define the expected configuration,
+			// we need to create a new instance of that type for FromYAMLFile to parse the configuration into.
+			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+
+			var err error
+			testutils.WithYAMLFile(t, data.Yaml, func(file *os.File) {
+				err = FromYAMLFile(file.Name(), actual)
+			})
+
+			return actual, err
+		}))
+	}
+
+	type invalidYamlTestCase struct {
 		// Test case name.
 		name string
 		// Content of the YAML file.
 		content string
-		// Expected configuration. Empty if parsing the content is expected to produce an error.
-		expected Validator
-		// Indicates if the configuration is expected to be invalid (by returning errInvalidConfiguration).
-		invalid bool
 	}
 
-	yamlTests := []yamlTestCase{
-		{
-			name:    "Simple YAML",
-			content: `key: value`,
-			expected: &simpleConfig{
-				Key: "value",
-			},
-		},
-		{
-			name: "Inlined YAML",
-			content: `
-key: value
-inlined-key: inlined-value`,
-			expected: &inlinedConfig{
-				Key:     "value",
-				Inlined: inlinedConfigPart{Key: "inlined-value"},
-			},
-		},
-		{
-			name: "Embedded YAML",
-			content: `
-key: value
-embedded:
-  embedded-key: embedded-value`,
-			expected: &embeddedConfig{
-				Key:      "value",
-				Embedded: embeddedConfigPart{Key: "embedded-value"},
-			},
-		},
-		{
-			name:    "Defaults",
-			content: `key: value`,
-			expected: &defaultConfig{
-				Key:     "value",
-				Default: defaultConfigPart{Key: "default-value"},
-			},
-		},
-		{
-			name: "Overriding Defaults",
-			content: `
-key: value
-default-key: overridden-value`,
-			expected: &defaultConfig{
-				Key:     "value",
-				Default: defaultConfigPart{Key: "overridden-value"},
-			},
-		},
+	invalidYamlTests := []invalidYamlTestCase{
 		{
 			name:    "Empty YAML",
 			content: "",
@@ -164,64 +264,23 @@ default-key: overridden-value`,
 			content: `:\n`,
 		},
 		{
-			name:    "Invalid YAML",
-			content: `key: value`,
-			expected: &invalidConfig{
-				Key: "value",
-			},
-			invalid: true,
+			name:    "Key only",
+			content: `key`,
 		},
 	}
 
-	for _, tc := range yamlTests {
+	for _, tc := range invalidYamlTests {
 		t.Run(tc.name, func(t *testing.T) {
-			yamlFile, err := os.CreateTemp("", "*.yaml")
-			require.NoError(t, err)
-
-			defer func(name string) {
-				_ = os.Remove(name)
-			}(yamlFile.Name())
-
-			require.NoError(t, os.WriteFile(yamlFile.Name(), []byte(tc.content), 0600))
-
-			if tc.expected != nil {
-				// Since our test cases only define the expected configuration,
-				// we need to create a new instance of that type for FromYAMLFile to parse the configuration into.
-				actual := reflect.New(reflect.TypeOf(tc.expected).Elem()).Interface().(Validator)
-				err := FromYAMLFile(yamlFile.Name(), actual)
-				if !tc.invalid {
-					require.NoError(t, err)
-				} else {
-					require.ErrorIs(t, err, errInvalidConfiguration)
-				}
-
-				require.Equal(t, tc.expected, actual)
-			} else {
-				err := FromYAMLFile(yamlFile.Name(), &validateValid{})
+			testutils.WithYAMLFile(t, tc.content, func(file *os.File) {
+				err := FromYAMLFile(file.Name(), &validateValid{})
 				require.Error(t, err)
-				// Assert that error is a parsing error.
+				// Since the YAML library does not export all possible error types,
+				// we must ensure that the error returned is not one of our own errors.
 				require.NotErrorIs(t, err, ErrInvalidArgument)
 				require.NotErrorIs(t, err, errInvalidConfiguration)
-			}
+			})
 		})
 	}
-
-	t.Run("Error propagation from defaults.Set()", func(t *testing.T) {
-		var config configWithInvalidDefault
-		var syntaxError *json.SyntaxError
-
-		yamlFile, err := os.CreateTemp("", "*.yaml")
-		require.NoError(t, err)
-		require.NoError(t, yamlFile.Close())
-		defer func(name string) {
-			_ = os.Remove(name)
-		}(yamlFile.Name())
-
-		require.NoError(t, os.WriteFile(yamlFile.Name(), []byte(`key: value`), 0600))
-
-		err = FromYAMLFile(yamlFile.Name(), &config)
-		require.ErrorAs(t, err, &syntaxError)
-	})
 
 	t.Run("Nil pointer argument", func(t *testing.T) {
 		var config *struct{ Validator }
@@ -328,97 +387,4 @@ func TestParseFlags(t *testing.T) {
 		// including "-h, --help Show this help message" (whitespace may vary).
 		require.Contains(t, string(out), "-h, --help")
 	})
-}
-
-type simpleValidator struct {
-	Foo int `env:"FOO"`
-}
-
-func (sv simpleValidator) Validate() error {
-	if sv.Foo == 42 {
-		return nil
-	} else {
-		return errors.New("invalid value")
-	}
-}
-
-type nonStructValidator int
-
-func (nonStructValidator) Validate() error {
-	return nil
-}
-
-type defaultValidator struct {
-	Foo int `env:"FOO" default:"42"`
-}
-
-func (defaultValidator) Validate() error {
-	return nil
-}
-
-type prefixValidator struct {
-	Nested simpleValidator `envPrefix:"PREFIX_"`
-}
-
-func (prefixValidator) Validate() error {
-	return nil
-}
-
-func TestFromEnv(t *testing.T) {
-	subtests := []struct {
-		name  string
-		opts  EnvOptions
-		io    Validator
-		error bool
-	}{
-		{name: "nil", error: true},
-		{name: "nonptr", io: simpleValidator{}, error: true},
-		{name: "nilptr", io: (*simpleValidator)(nil), error: true},
-		{name: "defaulterr", io: new(nonStructValidator), error: true},
-		{
-			name:  "parseeerr",
-			opts:  EnvOptions{Environment: map[string]string{"FOO": "bar"}},
-			io:    &simpleValidator{},
-			error: true,
-		},
-		{
-			name:  "invalid",
-			opts:  EnvOptions{Environment: map[string]string{"FOO": "23"}},
-			io:    &simpleValidator{},
-			error: true,
-		},
-		{name: "simple", opts: EnvOptions{Environment: map[string]string{"FOO": "42"}}, io: &simpleValidator{42}},
-		{name: "default", io: &defaultValidator{42}},
-		{name: "override", opts: EnvOptions{Environment: map[string]string{"FOO": "23"}}, io: &defaultValidator{23}},
-		{
-			name: "prefix",
-			opts: EnvOptions{Environment: map[string]string{"PREFIX_FOO": "42"}, Prefix: "PREFIX_"},
-			io:   &simpleValidator{42},
-		},
-		{
-			name: "nested",
-			opts: EnvOptions{Environment: map[string]string{"PREFIX_FOO": "42"}},
-			io:   &prefixValidator{simpleValidator{42}},
-		},
-	}
-
-	for _, st := range subtests {
-		t.Run(st.name, func(t *testing.T) {
-			var actual Validator
-			if vActual := reflect.ValueOf(st.io); vActual != (reflect.Value{}) {
-				if vActual.Kind() == reflect.Ptr && !vActual.IsNil() {
-					vActual = reflect.New(vActual.Type().Elem())
-				}
-
-				actual = vActual.Interface().(Validator)
-			}
-
-			if err := FromEnv(actual, st.opts); st.error {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, st.io, actual)
-			}
-		})
-	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -294,6 +294,19 @@ func TestFromYAMLFile(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidArgument)
 	})
 
+	t.Run("Non-struct pointer argument", func(t *testing.T) {
+		testutils.WithYAMLFile(t, `key: value`, func(file *os.File) {
+			var config nonStructValidator
+
+			err := FromYAMLFile(file.Name(), &config)
+			require.Error(t, err)
+			// Struct pointer assertion is done in the defaults library,
+			// so we must ensure that the error returned is not one of our own errors.
+			require.NotErrorIs(t, err, ErrInvalidArgument)
+			require.NotErrorIs(t, err, errInvalidConfiguration)
+		})
+	})
+
 	t.Run("Non-existent file", func(t *testing.T) {
 		var config struct{ validateValid }
 		var pathError *fs.PathError

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -3,102 +3,300 @@ package database
 import (
 	"github.com/creasty/defaults"
 	"github.com/icinga/icinga-go-library/config"
+	"github.com/icinga/icinga-go-library/testutils"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 )
+
+// minimalYaml is a constant string representing a minimal valid YAML configuration for
+// connecting to a PostgreSQL database. PostgreSQL is explicitly chosen here to
+// test whether the default type (which is MySQL) is correctly overridden.
+const minimalYaml = `
+type: pgsql
+host: localhost
+user: icinga
+database: icingadb
+password: secret`
+
+// minimalEnv returns a map of environment variables representing a minimal valid configuration for
+// connecting to a PostgreSQL database. PostgreSQL is explicitly chosen here to
+// test whether the default type (which is MySQL) is correctly overridden.
+func minimalEnv() map[string]string {
+	return map[string]string{
+		"TYPE":     "pgsql",
+		"HOST":     "localhost",
+		"USER":     "icinga",
+		"DATABASE": "icingadb",
+		"PASSWORD": "secret",
+	}
+}
+
+// withMinimalEnv takes a map of environment variables and merges it with the
+// minimal environment configuration returned from minimalEnv,
+// overriding any existing keys with the provided values.
+// It returns the resulting map.
+func withMinimalEnv(v map[string]string) map[string]string {
+	env := minimalEnv()
+
+	for key, value := range v {
+		env[key] = value
+	}
+
+	return env
+}
 
 func TestConfig(t *testing.T) {
 	var defaultOptions Options
 	require.NoError(t, defaults.Set(&defaultOptions), "setting default options")
 
-	subtests := []struct {
-		name     string
-		opts     config.EnvOptions
-		expected Config
-		error    bool
-	}{
+	configTests := []testutils.TestCase[Config, testutils.ConfigTestData]{
 		{
-			name:  "empty-missing-fields",
-			opts:  config.EnvOptions{},
-			error: true,
+			Name: "Unknown database type",
+			Data: testutils.ConfigTestData{
+				Yaml: `type: invalid`,
+				Env:  map[string]string{"TYPE": "invalid"},
+			},
+			Error: testutils.ErrorContains(`unknown database type "invalid"`),
 		},
 		{
-			name:  "unknown-db-type",
-			opts:  config.EnvOptions{Environment: map[string]string{"TYPE": "☃"}},
-			error: true,
+			Name: "Database host missing",
+			Data: testutils.ConfigTestData{
+				Yaml: `type: pgsql`,
+				Env:  map[string]string{"TYPE": "pgsql"},
+			},
+			Error: testutils.ErrorContains("database host missing"),
 		},
 		{
-			name: "minimal-config",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST":     "db.example.com",
-				"USER":     "user",
-				"DATABASE": "db",
-			}},
-			expected: Config{
-				Type:     "mysql",
-				Host:     "db.example.com",
-				Database: "db",
-				User:     "user",
+			Name: "Database user missing",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+type: pgsql
+host: localhost`,
+				Env: map[string]string{
+					"TYPE": "pgsql",
+					"HOST": "localhost",
+				},
+			},
+			Error: testutils.ErrorContains("database user missing"),
+		},
+		{
+			Name: "Database name missing",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+type: pgsql
+host: localhost
+user: icinga`,
+				Env: map[string]string{
+					"TYPE": "pgsql",
+					"HOST": "localhost",
+					"USER": "icinga",
+				},
+			},
+			Error: testutils.ErrorContains("database name missing"),
+		},
+		{
+			Name: "Minimal config",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml,
+				Env:  minimalEnv(),
+			},
+			Expected: Config{
+				Type:     "pgsql",
+				Host:     "localhost",
+				User:     "icinga",
+				Database: "icingadb",
+				Password: "secret",
 				Options:  defaultOptions,
 			},
 		},
 		{
-			name: "tls",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST":     "db.example.com",
-				"USER":     "user",
-				"DATABASE": "db",
-				"TLS":      "true",
-				"CERT":     "/var/empty/db.crt",
-				"CA":       "/var/empty/ca.crt",
-			}},
-			expected: Config{
-				Type:     "mysql",
-				Host:     "db.example.com",
-				Database: "db",
-				User:     "user",
-				TlsOptions: config.TLS{
-					Enable: true,
-					Cert:   "/var/empty/db.crt",
-					Ca:     "/var/empty/ca.crt",
+			Name: "Retain defaults",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+user: icinga
+database: icinga`,
+				Env: map[string]string{
+					"HOST":     "localhost",
+					"USER":     "icinga",
+					"DATABASE": "icinga",
 				},
-				Options: defaultOptions,
+			},
+			Expected: Config{
+				Type:     "mysql", // Default
+				Host:     "localhost",
+				User:     "icinga",
+				Database: "icinga",
+				Options:  defaultOptions,
 			},
 		},
 		{
-			name: "options",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST":                             "db.example.com",
-				"USER":                             "user",
-				"DATABASE":                         "db",
-				"OPTIONS_MAX_CONNECTIONS":          "1",
-				"OPTIONS_MAX_ROWS_PER_TRANSACTION": "65535",
-			}},
-			expected: Config{
-				Type:     "mysql",
-				Host:     "db.example.com",
-				Database: "db",
-				User:     "user",
+			Name: "TLS",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+tls: true
+cert: cert.pem
+key: key.pem
+ca: ca.pem`,
+				Env: withMinimalEnv(map[string]string{
+					"TLS":  "1",
+					"CERT": "cert.pem",
+					"KEY":  "key.pem",
+					"CA":   "ca.pem",
+				}),
+			},
+			Expected: Config{
+				Type:     "pgsql",
+				Host:     "localhost",
+				User:     "icinga",
+				Database: "icingadb",
+				Password: "secret",
+				Options:  defaultOptions,
+				TlsOptions: config.TLS{
+					Enable: true,
+					Cert:   "cert.pem",
+					Key:    "key.pem",
+					Ca:     "ca.pem",
+				},
+			},
+		},
+		{
+			Name: "max_connections cannot be 0",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_connections: 0`,
+				Env: withMinimalEnv(map[string]string{"OPTIONS_MAX_CONNECTIONS": "0"}),
+			},
+			Error: testutils.ErrorContains("max_connections cannot be 0"),
+		},
+		{
+			Name: "max_connections_per_table must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_connections_per_table: 0`,
+				Env: withMinimalEnv(map[string]string{"OPTIONS_MAX_CONNECTIONS_PER_TABLE": "0"}),
+			},
+			Error: testutils.ErrorContains("max_connections_per_table must be at least 1"),
+		},
+		{
+			Name: "max_placeholders_per_statement must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_placeholders_per_statement: 0`,
+				Env: withMinimalEnv(map[string]string{"OPTIONS_MAX_PLACEHOLDERS_PER_STATEMENT": "0"}),
+			},
+			Error: testutils.ErrorContains("max_placeholders_per_statement must be at least 1"),
+		},
+		{
+			Name: "max_rows_per_transaction must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_rows_per_transaction: 0`,
+				Env: withMinimalEnv(map[string]string{"OPTIONS_MAX_ROWS_PER_TRANSACTION": "0"}),
+			},
+			Error: testutils.ErrorContains("max_rows_per_transaction must be at least 1"),
+		},
+		{
+			Name: "wsrep_sync_wait can only be set to a number between 0 and 15",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  wsrep_sync_wait: 16`,
+				Env: withMinimalEnv(map[string]string{"OPTIONS_WSREP_SYNC_WAIT": "16"}),
+			},
+			Error: testutils.ErrorContains("wsrep_sync_wait can only be set to a number between 0 and 15"),
+		},
+		{
+			Name: "Options retain defaults",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_connections: 8
+  max_connections_per_table: 4`,
+				Env: withMinimalEnv(map[string]string{
+					"OPTIONS_MAX_CONNECTIONS":           "8",
+					"OPTIONS_MAX_CONNECTIONS_PER_TABLE": "4",
+				}),
+			},
+			Expected: Config{
+				Type:     "pgsql",
+				Host:     "localhost",
+				User:     "icinga",
+				Database: "icingadb",
+				Password: "secret",
 				Options: Options{
-					MaxConnections:              1,
-					MaxConnectionsPerTable:      8,
-					MaxPlaceholdersPerStatement: 8192,
-					MaxRowsPerTransaction:       65535,
-					WsrepSyncWait:               7,
+					MaxConnections:              8,
+					MaxConnectionsPerTable:      4,
+					MaxPlaceholdersPerStatement: defaultOptions.MaxPlaceholdersPerStatement,
+					MaxRowsPerTransaction:       defaultOptions.MaxRowsPerTransaction,
+					WsrepSyncWait:               defaultOptions.WsrepSyncWait,
+				},
+			},
+		},
+		{
+			Name: "Options",
+			Data: testutils.ConfigTestData{
+				Yaml: minimalYaml + `
+options:
+  max_connections: 8
+  max_connections_per_table: 4
+  max_placeholders_per_statement: 4096
+  max_rows_per_transaction: 2048
+  wsrep_sync_wait: 15`,
+				Env: withMinimalEnv(map[string]string{
+					"OPTIONS_MAX_CONNECTIONS":                "8",
+					"OPTIONS_MAX_CONNECTIONS_PER_TABLE":      "4",
+					"OPTIONS_MAX_PLACEHOLDERS_PER_STATEMENT": "4096",
+					"OPTIONS_MAX_ROWS_PER_TRANSACTION":       "2048",
+					"OPTIONS_WSREP_SYNC_WAIT":                "15",
+				}),
+			},
+			Expected: Config{
+				Type:     "pgsql",
+				Host:     "localhost",
+				User:     "icinga",
+				Database: "icingadb",
+				Password: "secret",
+				Options: Options{
+					MaxConnections:              8,
+					MaxConnectionsPerTable:      4,
+					MaxPlaceholdersPerStatement: 4096,
+					MaxRowsPerTransaction:       2048,
+					WsrepSyncWait:               15,
 				},
 			},
 		},
 	}
 
-	for _, test := range subtests {
-		t.Run(test.name, func(t *testing.T) {
-			var out Config
-			if err := config.FromEnv(&out, test.opts); test.error {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, test.expected, out)
-			}
-		})
-	}
+	t.Run("FromEnv", func(t *testing.T) {
+		for _, tc := range configTests {
+			t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Config, error) {
+				var actual Config
+
+				err := config.FromEnv(&actual, config.EnvOptions{Environment: data.Env})
+
+				return actual, err
+			}))
+		}
+	})
+
+	t.Run("FromYAMLFile", func(t *testing.T) {
+		for _, tc := range configTests {
+			t.Run(tc.Name+"/FromYAMLFile", tc.F(func(data testutils.ConfigTestData) (Config, error) {
+				var actual Config
+
+				var err error
+				testutils.WithYAMLFile(t, data.Yaml, func(file *os.File) {
+					err = config.FromYAMLFile(file.Name(), &actual)
+				})
+
+				return actual, err
+			}))
+		}
+	})
 }

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -3,7 +3,9 @@ package redis
 import (
 	"github.com/creasty/defaults"
 	"github.com/icinga/icinga-go-library/config"
+	"github.com/icinga/icinga-go-library/testutils"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 	"time"
 )
@@ -12,89 +14,259 @@ func TestConfig(t *testing.T) {
 	var defaultOptions Options
 	require.NoError(t, defaults.Set(&defaultOptions), "setting default options")
 
-	subtests := []struct {
-		name     string
-		opts     config.EnvOptions
-		expected Config
-		error    bool
-	}{
+	configTests := []testutils.TestCase[Config, testutils.ConfigTestData]{
 		{
-			name:  "empty-missing-host",
-			opts:  config.EnvOptions{},
-			error: true,
+			Name: "Redis host missing",
+			Data: testutils.ConfigTestData{
+				Yaml: `host:`,
+			},
+			Error: testutils.ErrorContains("Redis host missing"),
 		},
 		{
-			name: "minimal-config",
-			opts: config.EnvOptions{Environment: map[string]string{"HOST": "kv.example.com"}},
-			expected: Config{
-				Host:    "kv.example.com",
+			Name: "Minimal config",
+			Data: testutils.ConfigTestData{
+				Yaml: `host: localhost`,
+				Env:  map[string]string{"HOST": "localhost"},
+			},
+			Expected: Config{
+				Host:    "localhost",
 				Options: defaultOptions,
 			},
 		},
 		{
-			name: "customized-config",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST":     "kv.example.com",
-				"USERNAME": "user",
-				"PASSWORD": "insecure",
-				"DATABASE": "23",
-			}},
-			expected: Config{
-				Host:     "kv.example.com",
-				Username: "user",
-				Password: "insecure",
-				Database: 23,
+			Name: "Redis password must be set, if username is provided",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+username: username`,
+				Env: map[string]string{
+					"HOST":     "localhost",
+					"USERNAME": "username",
+				},
+			},
+			Error: testutils.ErrorContains("Redis password must be set, if username is provided"),
+		},
+		{
+			Name: "Customized config",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+username: username
+password: password
+database: 2`,
+				Env: map[string]string{
+					"HOST":     "localhost",
+					"USERNAME": "username",
+					"PASSWORD": "password",
+					"DATABASE": "2",
+				},
+			},
+			Expected: Config{
+				Host:     "localhost",
+				Username: "username",
+				Password: "password",
+				Database: 2,
 				Options:  defaultOptions,
 			},
 		},
 		{
-			name: "tls",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST": "kv.example.com",
-				"TLS":  "true",
-				"CERT": "/var/empty/db.crt",
-				"CA":   "/var/empty/ca.crt",
-			}},
-			expected: Config{
-				Host: "kv.example.com",
+			Name: "TLS",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+tls: true
+cert: cert.pem
+key: key.pem
+ca: ca.pem`,
+				Env: map[string]string{
+					"HOST": "localhost",
+					"TLS":  "1",
+					"CERT": "cert.pem",
+					"KEY":  "key.pem",
+					"CA":   "ca.pem",
+				},
+			},
+			Expected: Config{
+				Host:    "localhost",
+				Options: defaultOptions,
 				TlsOptions: config.TLS{
 					Enable: true,
-					Cert:   "/var/empty/db.crt",
-					Ca:     "/var/empty/ca.crt",
+					Cert:   "cert.pem",
+					Key:    "key.pem",
+					Ca:     "ca.pem",
 				},
-				Options: defaultOptions,
 			},
 		},
 		{
-			name: "options",
-			opts: config.EnvOptions{Environment: map[string]string{
-				"HOST":                          "kv.example.com",
-				"OPTIONS_BLOCK_TIMEOUT":         "1m",
-				"OPTIONS_MAX_HMGET_CONNECTIONS": "1000",
-			}},
-			expected: Config{
-				Host: "kv.example.com",
+			Name: "block_timeout must be positive",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  block_timeout: -1s`,
+				Env: map[string]string{
+					"HOST":                  "localhost",
+					"OPTIONS_BLOCK_TIMEOUT": "-1s",
+				},
+			},
+			Error: testutils.ErrorContains("block_timeout must be positive"),
+		},
+		{
+			Name: "hmget_count must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  hmget_count: 0`,
+				Env: map[string]string{
+					"HOST":                "localhost",
+					"OPTIONS_HMGET_COUNT": "0",
+				},
+			},
+			Error: testutils.ErrorContains("hmget_count must be at least 1"),
+		},
+		{
+			Name: "hscan_count must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  hscan_count: 0`,
+				Env: map[string]string{
+					"HOST":                "localhost",
+					"OPTIONS_HSCAN_COUNT": "0",
+				},
+			},
+			Error: testutils.ErrorContains("hscan_count must be at least 1"),
+		},
+		{
+			Name: "max_hmget_connections must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  max_hmget_connections: 0`,
+				Env: map[string]string{
+					"HOST":                          "localhost",
+					"OPTIONS_MAX_HMGET_CONNECTIONS": "0",
+				},
+			},
+			Error: testutils.ErrorContains("max_hmget_connections must be at least 1"),
+		},
+		{
+			Name: "timeout cannot be 0",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  timeout: 0s`,
+				Env: map[string]string{
+					"HOST":            "localhost",
+					"OPTIONS_TIMEOUT": "0s",
+				},
+			},
+			Error: testutils.ErrorContains("timeout cannot be 0. Configure a value greater than zero, or use -1 for no timeout"),
+		},
+		{
+			Name: "xread_count must be at least 1",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  xread_count: 0`,
+				Env: map[string]string{
+					"HOST":                "localhost",
+					"OPTIONS_XREAD_COUNT": "0",
+				},
+			},
+			Error: testutils.ErrorContains("xread_count must be at least 1"),
+		},
+		{
+			Name: "Options retain defaults",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  block_timeout: 2s
+  hmget_count: 512`,
+				Env: map[string]string{
+					"HOST":                  "localhost",
+					"OPTIONS_BLOCK_TIMEOUT": "2s",
+					"OPTIONS_HMGET_COUNT":   "512",
+				},
+			},
+			Expected: Config{
+				Host: "localhost",
 				Options: Options{
-					BlockTimeout:        time.Minute,
-					HMGetCount:          4096,
-					HScanCount:          4096,
-					MaxHMGetConnections: 1000,
-					Timeout:             30 * time.Second,
-					XReadCount:          4096,
+					BlockTimeout:        2 * time.Second,
+					HMGetCount:          512,
+					HScanCount:          defaultOptions.HScanCount,
+					MaxHMGetConnections: defaultOptions.MaxHMGetConnections,
+					Timeout:             defaultOptions.Timeout,
+					XReadCount:          defaultOptions.XReadCount,
+				},
+			},
+		},
+		{
+			Name: "Options",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+host: localhost
+options:
+  block_timeout: 2s
+  hmget_count: 512
+  hscan_count: 1024
+  max_hmget_connections: 16
+  timeout: 60s
+  xread_count: 2048`,
+				Env: map[string]string{
+					"HOST":                          "localhost",
+					"OPTIONS_BLOCK_TIMEOUT":         "2s",
+					"OPTIONS_HMGET_COUNT":           "512",
+					"OPTIONS_HSCAN_COUNT":           "1024",
+					"OPTIONS_MAX_HMGET_CONNECTIONS": "16",
+					"OPTIONS_TIMEOUT":               "60s",
+					"OPTIONS_XREAD_COUNT":           "2048",
+				},
+			},
+			Expected: Config{
+				Host: "localhost",
+				Options: Options{
+					BlockTimeout:        2 * time.Second,
+					HMGetCount:          512,
+					HScanCount:          1024,
+					MaxHMGetConnections: 16,
+					Timeout:             60 * time.Second,
+					XReadCount:          2048,
 				},
 			},
 		},
 	}
 
-	for _, test := range subtests {
-		t.Run(test.name, func(t *testing.T) {
-			var out Config
-			if err := config.FromEnv(&out, test.opts); test.error {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, test.expected, out)
-			}
-		})
-	}
+	t.Run("FromEnv", func(t *testing.T) {
+		for _, tc := range configTests {
+			t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Config, error) {
+				var actual Config
+
+				err := config.FromEnv(&actual, config.EnvOptions{Environment: data.Env})
+
+				return actual, err
+			}))
+		}
+	})
+
+	t.Run("FromYAMLFile", func(t *testing.T) {
+		for _, tc := range configTests {
+			t.Run(tc.Name+"/FromYAMLFile", tc.F(func(data testutils.ConfigTestData) (Config, error) {
+				var actual Config
+
+				var err error
+				testutils.WithYAMLFile(t, data.Yaml, func(file *os.File) {
+					err = config.FromYAMLFile(file.Name(), &actual)
+				})
+
+				return actual, err
+			}))
+		}
+	})
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -1,0 +1,96 @@
+// Package testutils provides utilities for testing, including generic test case structures
+// and helper functions for error checking and temporary file handling.
+//
+// This package is designed to simplify the process of writing tests by providing reusable
+// components that handle common testing scenarios, such as comparing expected and actual results,
+// checking for specific error conditions, and managing temporary files.
+package testutils
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+// TestCase represents a generic test case structure.
+// It is parameterized by T, the type of the expected result, and D, the type of the test data.
+// This struct is useful for defining test cases with expected outcomes and associated data.
+type TestCase[T comparable, D any] struct {
+	// Name is the identifier for the test case, used for reporting purposes.
+	Name string
+	// Expected is the anticipated result of the test. It should be left empty if an error is expected.
+	Expected T
+	// Data contains the input or configuration for the test case.
+	Data D
+	// Error is a function that checks the error returned by the test function, if an error is anticipated.
+	Error func(*testing.T, error)
+}
+
+// F returns a test function that executes the logic of the test case, suitable for use with t.Run().
+// It takes a function f that processes the test data and returns an actual result along with an error, if any.
+// After executing f, it verifies the actual result against the expected result or evaluates the error condition.
+func (tc TestCase[T, D]) F(f func(D) (T, error)) func(t *testing.T) {
+	return func(t *testing.T) {
+		actual, err := f(tc.Data)
+
+		if tc.Error != nil {
+			tc.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tc.Expected, actual)
+		}
+	}
+}
+
+// ConfigTestData holds test data for loading and validating configuration from
+// both YAML files and environment variables.
+type ConfigTestData struct {
+	// YAML file content to be tested.
+	Yaml string
+	// Environment variables to be used in the test.
+	Env map[string]string
+}
+
+// ErrorAs returns a function that checks if the error is of a specific type T.
+// This is useful for verifying that an error matches a particular interface or concrete type.
+func ErrorAs[T error]() func(t *testing.T, err error) {
+	return func(t *testing.T, err error) {
+		var expected T
+		require.ErrorAs(t, err, &expected)
+	}
+}
+
+// ErrorContains returns a function that checks if the error message contains the expected substring.
+// This is useful for validating that an error message includes specific information.
+func ErrorContains(expected string) func(t *testing.T, err error) {
+	return func(t *testing.T, err error) {
+		require.ErrorContains(t, err, expected)
+	}
+}
+
+// ErrorIs returns a function that checks if the error is equal to the expected error.
+// This is useful for confirming that an error is exactly the one anticipated.
+func ErrorIs(expected error) func(t *testing.T, err error) {
+	return func(t *testing.T, err error) {
+		require.ErrorIs(t, err, expected)
+	}
+}
+
+// WithYAMLFile creates a temporary YAML file with the provided content and executes a function with the file.
+// It ensures the file is removed after the function execution, preventing resource leaks.
+// This utility is helpful for tests that require file-based configuration.
+func WithYAMLFile(t *testing.T, yaml string, f func(file *os.File)) {
+	file, err := os.CreateTemp("", "*.yaml")
+	require.NoError(t, err)
+
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(file.Name())
+
+	_, err = file.WriteString(yaml)
+	require.NoError(t, err)
+
+	require.NoError(t, file.Close())
+
+	f(file)
+}


### PR DESCRIPTION
Since I want to merge the support for environment variables, but am unhappy with the tests implemented there, I have taken the liberty to take over and restructure all tests related to config:

- Both `FromEnv()` and `FromYAMLFile()` are tested in the `config` package, but also with our concrete config types `database#Config` and `redis#Config`.
- **Everything**, i.e. also the validation for config and options, is now tested.