### PR TITLE
Also validate that arguments to `config` functions are struct pointers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,7 +93,7 @@ func ParseFlags(v any) error {
 
 	if _, err := parser.Parse(); err != nil {
 		var flagErr *flags.Error
-		if errors.As(err, &flagErr) && flagErr.Type == flags.ErrHelp {
+		if errors.As(err, &flagErr) && errors.Is(flagErr.Type, flags.ErrHelp) {
 			fmt.Fprintln(os.Stdout, flagErr)
 			os.Exit(0)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ func FromYAMLFile(name string, v Validator) error {
 		return errors.WithStack(err)
 	}
 
-	// #nosec G304 -- Potential file inclusion via variable - Its purpose is to load any file name that is passed to it, so doesn't need to validate anything.
+	// #nosec G304 -- Accept user-controlled input for config file.
 	f, err := os.Open(name)
 	if err != nil {
 		return errors.Wrap(err, "can't open YAML file "+name)

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func ParseFlags(v any) error {
 	if _, err := parser.Parse(); err != nil {
 		var flagErr *flags.Error
 		if errors.As(err, &flagErr) && errors.Is(flagErr.Type, flags.ErrHelp) {
-			fmt.Fprintln(os.Stdout, flagErr)
+			_, _ = fmt.Fprintln(os.Stdout, flagErr)
 			os.Exit(0)
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -220,10 +220,7 @@ func TestFromEnv(t *testing.T) {
 		var config nonStructValidator
 
 		err := FromEnv(&config, EnvOptions{})
-		// Struct pointer assertion is done in the defaults library,
-		// so we must ensure that the error returned is not one of our own errors.
-		require.NotErrorIs(t, err, ErrInvalidArgument)
-		require.NotErrorIs(t, err, errInvalidConfiguration)
+		require.ErrorIs(t, err, ErrInvalidArgument)
 	})
 }
 
@@ -299,11 +296,7 @@ func TestFromYAMLFile(t *testing.T) {
 			var config nonStructValidator
 
 			err := FromYAMLFile(file.Name(), &config)
-			require.Error(t, err)
-			// Struct pointer assertion is done in the defaults library,
-			// so we must ensure that the error returned is not one of our own errors.
-			require.NotErrorIs(t, err, ErrInvalidArgument)
-			require.NotErrorIs(t, err, errInvalidConfiguration)
+			require.ErrorIs(t, err, ErrInvalidArgument)
 		})
 	})
 
@@ -359,6 +352,13 @@ func TestParseFlags(t *testing.T) {
 
 	t.Run("Nil argument", func(t *testing.T) {
 		err := ParseFlags(nil)
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Non-struct pointer argument", func(t *testing.T) {
+		var flags int
+
+		err := ParseFlags(&flags)
 		require.ErrorIs(t, err, ErrInvalidArgument)
 	})
 


### PR DESCRIPTION
Previously, the libraries used, i.e. `jessevdk/go-flags` and `creasty/defaults`, returned an error if the specified argument was not a struct pointer. We now do this in our validation.

The PR also introduces some minor code quality changes.