### PR TITLE
config: Pretty print yaml parser errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,10 @@ func FromYAMLFile(name string, v Validator) error {
 
 	d := yaml.NewDecoder(f, yaml.DisallowUnknownField())
 	if err := d.Decode(v); err != nil {
+		// The PrettyPrint() method of the yaml parser errors doesn't get triggered automatically, so we've to do
+		// it via the `yaml.FormatError` helper function. If the provided error implements `yaml.errors.PrettyPrinter`
+		// we'll get the prettified string of that type, otherwise just error string.
+		err = errors.New(yaml.FormatError(err, true, true))
 		return errors.Wrap(err, "can't parse YAML file "+name)
 	}
 


### PR DESCRIPTION
The `PrettyPrint()` method of the yaml errors doesn't get triggered automatically, so we've to do it via the `yaml.FormatError()` helper function. This will return the prettified string of the provided error, if it implements the `yaml.errors#PrettyPrinter` interface, otherwise just the error string.

### Before

```bash
~/Workspace/go/icingadb (main ✗) go run cmd/icingadb/main.go --config config.example.yml
can't parse YAML file config.example.yml: cannot unmarshal -1 into Go value of type uint16 ( overflow )
exit status 1
```

### After

![Bildschirmfoto 2024-10-30 um 09 42 27](https://github.com/user-attachments/assets/a08f374f-649e-47a2-b64a-42ec04324fea)

resolves https://github.com/Icinga/icingadb/issues/755