### PR TITLE
Support loading configuration from both YAML files and env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 // Package config provides utilities for configuration parsing and loading.
-// It includes functionality for handling command-line flags and loading configuration from YAML files,
+// It includes functionality for handling command-line flags and loading configuration from YAML files
 // with additional support for setting default values and validation.
 // Additionally, it provides a struct that defines common settings for a TLS client.
 //
@@ -56,12 +56,12 @@ import (
 	"reflect"
 )
 
-// ErrInvalidArgument is the error returned by [ParseFlags] or [FromYAMLFile] if
-// its parsing result cannot be stored in the value pointed to by the designated passed argument which
-// must be a non-nil struct pointer.
+// ErrInvalidArgument is the error returned by any function that loads configuration if
+// the parsing result cannot be stored in the value pointed to by the specified argument,
+// which must be a non-nil struct pointer.
 var ErrInvalidArgument = stderrors.New("invalid argument")
 
-// ErrInvalidConfiguration is attached to errors returned by [FromYAMLFile] or [FromEnv] when
+// ErrInvalidConfiguration is attached to errors returned by any function that loads configuration when
 // the configuration is invalid,
 // i.e. if the Validate method of the provided [Validator] interface returns an error,
 // which is then propagated by these functions.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,9 +194,7 @@ default-key: overridden-value`,
 func TestFromEnv(t *testing.T) {
 	for _, tc := range configTests {
 		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
-			// Since our test cases only define the expected configuration,
-			// we need to create a new instance of that type for FromEnv to parse the configuration into.
-			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+			actual := createValidatorInstance(tc.Expected)
 
 			err := FromEnv(actual, EnvOptions{Environment: data.Env})
 
@@ -227,9 +225,7 @@ func TestFromEnv(t *testing.T) {
 func TestFromYAMLFile(t *testing.T) {
 	for _, tc := range configTests {
 		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
-			// Since our test cases only define the expected configuration,
-			// we need to create a new instance of that type for FromYAMLFile to parse the configuration into.
-			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+			actual := createValidatorInstance(tc.Expected)
 
 			var err error
 			testutils.WithYAMLFile(t, data.Yaml, func(file *os.File) {
@@ -405,9 +401,7 @@ func TestLoad(t *testing.T) {
 
 	for _, tc := range loadTests {
 		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
-			// Since our test cases only define the expected configuration,
-			// we need to create a new instance of that type for Load to parse the configuration into.
-			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+			actual := createValidatorInstance(tc.Expected)
 
 			var err error
 			if data.Yaml != "" {
@@ -527,4 +521,12 @@ func TestParseFlags(t *testing.T) {
 		// including "-h, --help Show this help message" (whitespace may vary).
 		require.Contains(t, string(out), "-h, --help")
 	})
+}
+
+// createValidatorInstance creates a new instance of the same type as the provided value.
+//
+// Since our test cases only define the expected configuration,
+// we need to create a new instance of that type for our functions to parse the configuration into.
+func createValidatorInstance(v Validator) Validator {
+	return reflect.New(reflect.TypeOf(v).Elem()).Interface().(Validator)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -301,11 +301,8 @@ func TestFromYAMLFile(t *testing.T) {
 	})
 
 	t.Run("Non-existent file", func(t *testing.T) {
-		var pathError *fs.PathError
-
 		err := FromYAMLFile("nonexistent.yaml", &validateValid{})
-		require.ErrorAs(t, err, &pathError)
-		require.ErrorIs(t, pathError.Err, fs.ErrNotExist)
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 
 	t.Run("Permission denied", func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -324,6 +324,138 @@ func TestFromYAMLFile(t *testing.T) {
 	})
 }
 
+// testFlags is a struct that implements the Flags interface.
+// It holds information about the configuration file path and whether it was explicitly set.
+type testFlags struct {
+	configPath         string // The path to the configuration file.
+	explicitConfigPath bool   // Indicates if the config path was explicitly set.
+}
+
+// GetConfigPath returns the path to the configuration file.
+func (f testFlags) GetConfigPath() string {
+	return f.configPath
+}
+
+// IsExplicitConfigPath indicates whether the configuration file path was explicitly set.
+func (f testFlags) IsExplicitConfigPath() bool {
+	return f.explicitConfigPath
+}
+
+func TestLoad(t *testing.T) {
+	loadTests := []testutils.TestCase[Validator, testutils.ConfigTestData]{
+		{
+			Name: "Load from YAML only",
+			Data: testutils.ConfigTestData{
+				Yaml: `key: value`,
+			},
+			Expected: &simpleConfig{
+				Key: "value",
+			},
+		},
+		{
+			Name: "Load from Env only",
+			Data: testutils.ConfigTestData{
+				Env: map[string]string{"KEY": "value"},
+			},
+			Expected: &simpleConfig{
+				Key: "value",
+			},
+		},
+		{
+			Name: "YAML and Env; Env overrides",
+			Data: testutils.ConfigTestData{
+				Yaml: `key: yaml-value`,
+				Env:  map[string]string{"KEY": "env-value"},
+			},
+			Expected: &simpleConfig{
+				Key: "env-value",
+			},
+		},
+		{
+			Name: "YAML and Env; Env overrides defaults",
+			Data: testutils.ConfigTestData{
+				Yaml: `key: yaml-value`,
+				Env: map[string]string{
+					"DEFAULT_KEY": "env-value",
+				}},
+			Expected: &defaultConfig{
+				Key:     "yaml-value",
+				Default: defaultConfigPart{Key: "env-value"},
+			},
+		},
+		{
+			Name: "YAML and Env; Env supplements",
+			Data: testutils.ConfigTestData{
+				Yaml: `key: yaml-value`,
+				Env:  map[string]string{"EMBEDDED_EMBEDDED_KEY": "env-value"}},
+			Expected: &embeddedConfig{
+				Key:      "yaml-value",
+				Embedded: embeddedConfigPart{Key: "env-value"},
+			},
+		},
+		{
+			Name: "Validate invalid",
+			Data: testutils.ConfigTestData{
+				Yaml: `key: value`,
+				Env:  map[string]string{"KEY": "value"},
+			},
+			Expected: &invalidConfig{
+				Key: "value",
+			},
+			Error: testutils.ErrorIs(errInvalidConfiguration),
+		},
+	}
+
+	for _, tc := range loadTests {
+		t.Run(tc.Name, tc.F(func(data testutils.ConfigTestData) (Validator, error) {
+			// Since our test cases only define the expected configuration,
+			// we need to create a new instance of that type for Load to parse the configuration into.
+			actual := reflect.New(reflect.TypeOf(tc.Expected).Elem()).Interface().(Validator)
+
+			var err error
+			if data.Yaml != "" {
+				testutils.WithYAMLFile(t, data.Yaml, func(file *os.File) {
+					err = Load(actual, LoadOptions{
+						Flags: testFlags{
+							configPath:         file.Name(),
+							explicitConfigPath: true,
+						},
+						EnvOptions: EnvOptions{Environment: data.Env},
+					})
+				})
+			} else {
+				err = Load(actual, LoadOptions{Flags: testFlags{}, EnvOptions: EnvOptions{Environment: data.Env}})
+			}
+
+			return actual, err
+		}))
+	}
+
+	t.Run("Nil pointer argument", func(t *testing.T) {
+		var config *struct{ Validator }
+
+		err := Load(config, LoadOptions{})
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Nil argument", func(t *testing.T) {
+		err := Load(nil, LoadOptions{})
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Non-struct pointer argument", func(t *testing.T) {
+		var config nonStructValidator
+
+		err := Load(config, LoadOptions{})
+		require.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	t.Run("Explicit config; file does not exist", func(t *testing.T) {
+		err := Load(&validateValid{}, LoadOptions{Flags: testFlags{explicitConfigPath: true}})
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+}
+
 func TestParseFlags(t *testing.T) {
 	t.Run("Simple flags", func(t *testing.T) {
 		originalArgs := os.Args

--- a/config/contracts.go
+++ b/config/contracts.go
@@ -1,6 +1,6 @@
 package config
 
-// Validator is an interface that must be implemented by any configuration struct used in [FromYAMLFile].
+// Validator is an interface that must be implemented by any struct into which configuration is intended to be loaded.
 //
 // The Validate method checks the configuration values and
 // returns an error if any value is invalid or missing when required.

--- a/config/contracts.go
+++ b/config/contracts.go
@@ -15,3 +15,17 @@ type Validator interface {
 	// returns an error if any value is invalid or missing when required.
 	Validate() error
 }
+
+// Flags is an interface that provides methods related to access the
+// configuration file path specified via command line flags.
+// This interface is meant to be implemented by flag structs containing
+// a switch for the configuration file path.
+type Flags interface {
+	// GetConfigPath retrieves the path to the configuration file as specified by command line flags,
+	// or returns a default path if none was provided.
+	GetConfigPath() string
+
+	// IsExplicitConfigPath indicates whether the configuration file path was
+	// explicitly set through command line flags.
+	IsExplicitConfigPath() bool
+}


### PR DESCRIPTION
This PR introduces `config.Load()` that supports configuration loading  in three scenarios:

1. Load configuration solely from YAML files when no relevant environment variables are set.
2. Combine YAML file and environment variable configurations, allowing environment variables to supplement or override possible incomplete YAML configurations.
3. Load entirely from environment variables if the default YAML config file is absent and no specific config path is provided by the user.

`config.FromYAMLFile()` is still called first but continuation with `config.FromEnv()` is allowed by handling:
* **ErrInvalidConfiguration**: The configuration may be incomplete and will be revalidated in `config.FromEnv()`.
* **Non-existent file errors**: If no explicit config path is set, fallback to environment variables is allowed.

`config.FromEnv()` is called regardless of the outcome from `config.FromYAMLFile()`. If no environment variables are set, configuration relies entirely on YAML. Otherwise, environment variables can supplement, override YAML settings, or serve as the sole source. `config.FromEnv()` also includes validation, ensuring completeness after considering both sources.

Possible alternative implementations:

* If the config path is the default, `os.Stat()` could be used before calling `config.FromYAMLFile()`, rather than handling non-existent file errors. This approach would split the logic into two sections and add an additional if block.
* Don't call `Validate()` in the config package automatically. Instead, require it to be called manually. I appreciate that library-wise, both `config.FromYAMLFile()` and `config.FromEnv()` include validation allowing them to be used without needing an additional function call on their own. When combining them, I think it's straightforward to use `errors.Is()` to check for `ErrInvalidConfiguration`, i.e. errors from `Validate()`. 

requires #83 