### PR TITLE
logging: ForceLog option to log all messages

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -117,3 +117,14 @@ func (l *Logging) GetChildLogger(name string) *Logger {
 func (l *Logging) GetLogger() *Logger {
 	return l.logger
 }
+
+// ForceLog results in every message being logged.
+//
+// This [zap.Option] is the opposite of [zap.IncreaseLevel], it just decreases the log level to debug. Since zap's
+// architecture does not allow this with the same [zapcore.Core], it replaces the core with a freshly created one from
+// the Logging's core factory.
+func (l *Logging) ForceLog() zap.Option {
+	return zap.WrapCore(func(_ zapcore.Core) zapcore.Core {
+		return l.coreFactory(zap.NewAtomicLevelAt(zapcore.DebugLevel))
+	})
+}


### PR DESCRIPTION
Once a zap logger is created, its minimum log level is set in its core. It is possible to log at this level or at a higher level, for example, when setting info, one can log at info or error. However, it is not possible to decrease the level of the logger.

This can be useful when the user has configured a high default level, but some messages still need to be logged without giving them a ridiculously high level, e.g., a start log entry with a version string as an error log entry.