### PR TITLE
database,redis: More verbosity in OnRetryableError

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -879,10 +879,11 @@ func (db *DB) HasTable(ctx context.Context, table string) (bool, error) {
 func (db *DB) GetDefaultRetrySettings() retry.Settings {
 	return retry.Settings{
 		Timeout: retry.DefaultTimeout,
-		OnRetryableError: func(_ time.Duration, _ uint64, err, lastErr error) {
-			if lastErr == nil || err.Error() != lastErr.Error() {
-				db.logger.Warnw("Can't execute query. Retrying", zap.Error(err))
-			}
+		OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
+			db.logger.Warnw("Can't execute query. Retrying",
+				zap.Error(err),
+				zap.Duration("after", elapsed),
+				zap.Uint64("attempt", attempt))
 		},
 		OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
 			if attempt > 1 {

--- a/database/driver.go
+++ b/database/driver.go
@@ -67,9 +67,10 @@ func (c RetryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 					c.callbacks.OnRetryableError(elapsed, attempt, err, lastErr)
 				}
 
-				if lastErr == nil || err.Error() != lastErr.Error() {
-					c.logger.Warnw("Can't connect to database. Retrying", zap.Error(err))
-				}
+				c.logger.Warnw("Can't connect to database. Retrying",
+					zap.Error(err),
+					zap.Duration("after", elapsed),
+					zap.Uint64("attempt", attempt))
 			},
 			OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
 				if c.callbacks.OnSuccess != nil {

--- a/redis/client.go
+++ b/redis/client.go
@@ -310,10 +310,11 @@ func dialWithLogging(dialer ctxDialerFunc, logger *logging.Logger) ctxDialerFunc
 			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
 			retry.Settings{
 				Timeout: retry.DefaultTimeout,
-				OnRetryableError: func(_ time.Duration, _ uint64, err, lastErr error) {
-					if lastErr == nil || err.Error() != lastErr.Error() {
-						logger.Warnw("Can't connect to Redis. Retrying", zap.Error(err))
-					}
+				OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
+					logger.Warnw("Can't connect to Redis. Retrying",
+						zap.Error(err),
+						zap.Duration("after", elapsed),
+						zap.Uint64("attempt", attempt))
 				},
 				OnSuccess: func(elapsed time.Duration, attempt uint64, _ error) {
 					if attempt > 1 {


### PR DESCRIPTION
    database,redis: More verbosity in OnRetryableError

    The OnRetryableError functions came with conditions to only log the
    error if it had changed since the last iteration. While this keeps the
    log file clean, it hides reoccurring errors and makes it harder to
    identify specific errors.

    The changed version always logs the reoccurring error and also includes
    the duration since the start and the current attempt.
