### PR TITLE
config: unset TLS Key environment variable

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -41,7 +41,7 @@ type TLS struct {
 
 	// Key is either the path to the TLS key file or a raw PEM-encoded string representing it.
 	// If specified, Cert must also be provided.
-	Key string `yaml:"key" env:"KEY"`
+	Key string `yaml:"key" env:"KEY,unset"`
 
 	// Ca is either the path to the CA certificate file or a raw PEM-encoded string representing it.
 	Ca string `yaml:"ca" env:"CA"`


### PR DESCRIPTION
Unset the TLS private key environment variable after usage. Since this field can store both the path to a private key as well as a raw private key, it should be unset to not be available to child processes, e.g., an Icinga Notifications channel plugin.