### PR TITLE
Import Icinga Notifications `internal/utils`

### DIFF
--- a/database/utils.go
+++ b/database/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
+	"slices"
 	"strings"
 )
 
@@ -82,15 +83,11 @@ func InsertObtainID(ctx context.Context, conn TxOrDB, stmt string, arg any) (int
 	return resultID, nil
 }
 
-// BuildInsertStmtWithout builds an insert stmt without the provided column.
-func BuildInsertStmtWithout(db *DB, into interface{}, withoutColumn string) string {
-	columns := db.BuildColumns(into)
-	for i, column := range columns {
-		if column == withoutColumn {
-			columns = append(columns[:i], columns[i+1:]...)
-			break
-		}
-	}
+// BuildInsertStmtWithout builds an insert stmt without the provided columns.
+func BuildInsertStmtWithout(db *DB, into interface{}, withoutColumns ...string) string {
+	columns := slices.DeleteFunc(
+		db.BuildColumns(into),
+		func(column string) bool { return slices.Contains(withoutColumns, column) })
 
 	return fmt.Sprintf(
 		`INSERT INTO "%s" ("%s") VALUES (%s)`,

--- a/database/utils.go
+++ b/database/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 // CantPerformQuery wraps the given error with the specified query that cannot be executed.
@@ -79,6 +80,23 @@ func InsertObtainID(ctx context.Context, conn TxOrDB, stmt string, arg any) (int
 	}
 
 	return resultID, nil
+}
+
+// BuildInsertStmtWithout builds an insert stmt without the provided column.
+func BuildInsertStmtWithout(db *DB, into interface{}, withoutColumn string) string {
+	columns := db.BuildColumns(into)
+	for i, column := range columns {
+		if column == withoutColumn {
+			columns = append(columns[:i], columns[i+1:]...)
+			break
+		}
+	}
+
+	return fmt.Sprintf(
+		`INSERT INTO "%s" ("%s") VALUES (%s)`,
+		TableName(into), strings.Join(columns, `", "`),
+		fmt.Sprintf(":%s", strings.Join(columns, ", :")),
+	)
 }
 
 // unsafeSetSessionVariableIfExists sets the given MySQL/MariaDB system variable for the specified database session.

--- a/types/int.go
+++ b/types/int.go
@@ -14,6 +14,29 @@ type Int struct {
 	sql.NullInt64
 }
 
+// TransformZeroIntToNull transforms a valid Int carrying a zero value to a SQL NULL.
+func TransformZeroIntToNull(i *Int) {
+	if i.Valid && i.Int64 == 0 {
+		i.Valid = false
+	}
+}
+
+// MakeInt constructs a new Int.
+//
+// Multiple transformer functions can be given, each transforming the generated Int, e.g., TransformZeroIntToNull.
+func MakeInt(in int64, transformers ...func(*Int)) Int {
+	i := Int{sql.NullInt64{
+		Int64: in,
+		Valid: true,
+	}}
+
+	for _, transformer := range transformers {
+		transformer(&i)
+	}
+
+	return i
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 // Supports JSON null.
 func (i Int) MarshalJSON() ([]byte, error) {

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -6,6 +6,49 @@ import (
 	"testing"
 )
 
+func TestMakeInt(t *testing.T) {
+	subtests := []struct {
+		name         string
+		input        int64
+		transformers []func(*Int)
+		output       sql.NullInt64
+	}{
+		{
+			name:   "zero",
+			input:  0,
+			output: sql.NullInt64{Int64: 0, Valid: true},
+		},
+		{
+			name:   "positive",
+			input:  1,
+			output: sql.NullInt64{Int64: 1, Valid: true},
+		},
+		{
+			name:   "negative",
+			input:  -1,
+			output: sql.NullInt64{Int64: -1, Valid: true},
+		},
+		{
+			name:         "zero-transform-zero-to-null",
+			input:        0,
+			transformers: []func(*Int){TransformZeroIntToNull},
+			output:       sql.NullInt64{Valid: false},
+		},
+		{
+			name:         "positive-transform-zero-to-null",
+			input:        1,
+			transformers: []func(*Int){TransformZeroIntToNull},
+			output:       sql.NullInt64{Int64: 1, Valid: true},
+		},
+	}
+
+	for _, st := range subtests {
+		t.Run(st.name, func(t *testing.T) {
+			require.Equal(t, Int{NullInt64: st.output}, MakeInt(st.input, st.transformers...))
+		})
+	}
+}
+
 func TestInt_MarshalJSON(t *testing.T) {
 	subtests := []struct {
 		name   string

--- a/types/string.go
+++ b/types/string.go
@@ -14,12 +14,27 @@ type String struct {
 	sql.NullString
 }
 
-// MakeString constructs a new non-NULL String from s.
-func MakeString(s string) String {
-	return String{sql.NullString{
-		String: s,
+// TransformEmptyStringToNull transforms a valid String carrying an empty text to a SQL NULL.
+func TransformEmptyStringToNull(s *String) {
+	if s.Valid && s.String == "" {
+		s.Valid = false
+	}
+}
+
+// MakeString constructs a new String.
+//
+// Multiple transformer functions can be given, each transforming the generated String, e.g., TransformEmptyStringToNull.
+func MakeString(in string, transformers ...func(*String)) String {
+	s := String{sql.NullString{
+		String: in,
 		Valid:  true,
 	}}
+
+	for _, transformer := range transformers {
+		transformer(&s)
+	}
+
+	return s
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/utf8string"
+	"iter"
 	"net"
 	"os"
 	"path/filepath"
@@ -170,11 +171,7 @@ func PrintErrorThenExit(err error, exitCode int) {
 //
 // This function returns a func yielding key-value-pairs from a given map in the order of their keys, if their type
 // is cmp.Ordered.
-//
-// Please note that currently - being at Go 1.22 - rangefuncs are still an experimental feature and cannot be directly
-// used unless compiled with `GOEXPERIMENT=rangefunc`. However, they can still be invoked normally.
-// https://go.dev/wiki/RangefuncExperiment
-func IterateOrderedMap[K cmp.Ordered, V any](m map[K]V) func(func(K, V) bool) {
+func IterateOrderedMap[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
 	keys := make([]K, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -50,5 +51,54 @@ func requireClosedEmpty(t *testing.T, ch <-chan int) {
 		require.False(t, ok, "receiving from channel should not return anything")
 	default:
 		require.Fail(t, "receiving should not block")
+	}
+}
+
+func TestIterateOrderedMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      map[int]string
+		outKeys []int
+	}{
+		{"empty", map[int]string{}, nil},
+		{"single", map[int]string{1: "foo"}, []int{1}},
+		{"few-numbers", map[int]string{1: "a", 2: "b", 3: "c"}, []int{1, 2, 3}},
+		{
+			"1k-numbers",
+			func() map[int]string {
+				m := make(map[int]string)
+				for i := 0; i < 1000; i++ {
+					m[i] = "foo"
+				}
+				return m
+			}(),
+			func() []int {
+				keys := make([]int, 1000)
+				for i := 0; i < 1000; i++ {
+					keys[i] = i
+				}
+				return keys
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var outKeys []int
+
+			// Either run with GOEXPERIMENT=rangefunc or wait for rangefuncs to land in the next Go release.
+			// for k, _ := range IterateOrderedMap(tt.in) {
+			// 	outKeys = append(outKeys, k)
+			// }
+
+			// In the meantime, it can be invoked as follows.
+			IterateOrderedMap(tt.in)(func(k int, v string) bool {
+				assert.Equal(t, tt.in[k], v)
+				outKeys = append(outKeys, k)
+				return true
+			})
+
+			assert.Equal(t, tt.outKeys, outKeys)
+		})
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -85,18 +85,10 @@ func TestIterateOrderedMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var outKeys []int
-
-			// Either run with GOEXPERIMENT=rangefunc or wait for rangefuncs to land in the next Go release.
-			// for k, _ := range IterateOrderedMap(tt.in) {
-			// 	outKeys = append(outKeys, k)
-			// }
-
-			// In the meantime, it can be invoked as follows.
-			IterateOrderedMap(tt.in)(func(k int, v string) bool {
+			for k, v := range IterateOrderedMap(tt.in) {
 				assert.Equal(t, tt.in[k], v)
 				outKeys = append(outKeys, k)
-				return true
-			})
+			}
 
 			assert.Equal(t, tt.outKeys, outKeys)
 		})


### PR DESCRIPTION
This PR imports the `internal/utils` package from Icinga Notifications into `utils` for general purpose functions and into `database` for database-related utility functions. The commit history was kept, but messages were slightly altered since the original messages often referred changes outside the `internal/utils` package.

My motivation for this merge was to use a utility function already implemented, but residing in the wrong project's utility package. Since the IGL is the place for common code, I would like to get rid of utility packages outside this repository.

<details><summary>Steps performed to create this PR</summary>
<p>

## Create Patches

Within the `icinga-notifications` repository.

```sh
$ cd internal/utils
$ git format-patch --relative --root -- ./
0001-Introduce-utils-package.patch
0002-Move-helper-function-to-utils-package.patch
0003-Implement-incremental-config-updates-for-rules.patch
0004-Add-utils-ToDBInt-function.patch
0005-Use-sqlx.Tx-for-event-processing.patch
0006-Use-ctx-everywhere-cache-object-only-when-the-tx-suc.patch
0007-Trigger-time-based-escalations.patch
0008-Rename-and-simplify-restoreAttrsFor-function.patch
0009-Make-sure-to-release-semaphore-in-utils-ForEachRow.patch
0010-utils.IterateOrderedMap-for-plugin.FormatMessage.patch
0011-Switch-to-icinga-go-library.patch
0012-Drop-unused-Remove-utils-functions.patch
0013-Restore-all-muted-objects-without-an-incident-on-dae.patch
0014-Make-logging-more-consistent.patch
0015-Use-utils.IterateOrderedMap-as-intended-via-for-rang.patch
$ cd -
$ mv internal/utils/*.patch .
$ ls *.patch
```


## Apply Patches

Within this repository.

First, create a `githook(5)` to verify each applied patch works.
Plot twist: each patch will fail now.

```sh
$ cat .git/hooks/pre-applypatch
#!/usr/bin/env bash
#
# An example hook script to verify what is about to be committed
# by applypatch from an e-mail message.
#
# The hook should exit with non-zero status after issuing an
# appropriate message if it wants to stop the commit.
#
# To enable this hook, rename this file to "pre-applypatch".

. git-sh-setup
precommit="$(git rev-parse --git-path hooks/pre-commit)"
test -x "$precommit" && exec "$precommit" ${1+"$@"}

go build
go test -race -count=1 ./...
```

Start applying patches:

```sh
$ git am -3 --directory utils/ ../icinga-notifications/*.patch
```

Each patch now requires some manual intervention, e.g., making it compile or manually move some code to `./database/util.go`.

If the current patch works, build it manually once and continue afterwards.

```sh
$ git add utils/ database/ && git am --continue
```

The `0011-Switch-to-icinga-go-library.patch` patch was skipped since it does not made sense in this context.


## Verifying Methods

To make sure that nothing was lost, I have manually diffed each function.

```diff
@@ -1,5 +1,5 @@
 // BuildInsertStmtWithout builds an insert stmt without the provided column.
-func BuildInsertStmtWithout(db *database.DB, into interface{}, withoutColumn string) string {
+func BuildInsertStmtWithout(db *DB, into interface{}, withoutColumn string) string {
        columns := db.BuildColumns(into)
        for i, column := range columns {
                if column == withoutColumn {
@@ -11,7 +11,7 @@

        return fmt.Sprintf(
                `INSERT INTO "%s" ("%s") VALUES (%s)`,
-               database.TableName(into), strings.Join(columns, `", "`),
+               TableName(into), strings.Join(columns, `", "`),
                fmt.Sprintf(":%s", strings.Join(columns, ", :")),
        )
 }
```

```diff
@@ -3,7 +3,7 @@
 // A new transaction is started on db which is then passed to fn. After fn returns, the transaction is
 // committed unless an error was returned. If fn returns an error, that error is returned, otherwise an
 // error is returned if a database operation fails.
-func RunInTx(ctx context.Context, db *database.DB, fn func(tx *sqlx.Tx) error) error {
+func RunInTx(ctx context.Context, db *DB, fn func(tx *sqlx.Tx) error) error {
        tx, err := db.BeginTxx(ctx, nil)
        if err != nil {
                return err
```

```diff
@@ -1,7 +1,7 @@
 // InsertAndFetchId executes the given query and fetches the last inserted ID.
 func InsertAndFetchId(ctx context.Context, tx *sqlx.Tx, stmt string, args any) (int64, error) {
        var lastInsertId int64
-       if tx.DriverName() == database.PostgreSQL {
+       if tx.DriverName() == PostgreSQL {
                preparedStmt, err := tx.PrepareNamedContext(ctx, stmt+" RETURNING id")
                if err != nil {
                        return 0, err
```

```diff
@@ -1,7 +1,7 @@
 // ExecAndApply applies the provided restoreFunc callback for each successfully retrieved row of the specified type.
 // Returns error on any database failure or fails to acquire the table semaphore.
-func ExecAndApply[Row any](ctx context.Context, db *database.DB, stmt string, args []interface{}, restoreFunc func(*Row)) error {
-       table := database.TableName(new(Row))
+func ExecAndApply[Row any](ctx context.Context, db *DB, stmt string, args []interface{}, restoreFunc func(*Row)) error {
+       table := TableName(new(Row))
        sem := db.GetSemaphoreForTable(table)
        if err := sem.Acquire(ctx, 1); err != nil {
                return errors.Wrapf(err, "cannot acquire semaphore for table %q", table)
```

```diff
@@ -1,7 +1,7 @@
 // ForEachRow applies the provided restoreFunc callback for each successfully retrieved row of the specified type.
 // It will bulk SELECT the data from the database scoped to the specified ids and scans into the provided Row type.
 // Returns error on any database failure or fails to acquire the table semaphore.
-func ForEachRow[Row, Id any](ctx context.Context, db *database.DB, idColumn string, ids []Id, restoreFunc func(*Row)) error {
+func ForEachRow[Row, Id any](ctx context.Context, db *DB, idColumn string, ids []Id, restoreFunc func(*Row)) error {
        subject := new(Row)
        query := fmt.Sprintf("%s WHERE %q IN (?)", db.BuildSelectStmt(subject, subject), idColumn)
        stmt, args, err := sqlx.In(query, ids)
```

No diff for `ToDBString`, `ToDBInt`, and `IterateOrderedMap`.


## Reword Commit Messages

Since most commit messages referred a certain change and the changes in the `util.go` file was a drive-by change, I have reworded each commit message and linked the original commit on GitHub.

## Cleanup

As further specified in <https://github.com/Icinga/icinga-go-library/pull/127#issuecomment-2838713035>, some functions and commits were dropped again.

</p>
</details> 