### PR TITLE
backoff: Ensure bounds and introduce default value

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -8,6 +8,9 @@ import (
 // Backoff returns the backoff duration for a specific retry attempt.
 type Backoff func(uint64) time.Duration
 
+// DefaultBackoff is our opinionated Backoff function for retry.WithBackoff - between 128ms and 1m.
+var DefaultBackoff = NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute)
+
 // NewExponentialWithJitter returns an exponentially increasing [Backoff] implementation.
 //
 // The calculated [time.Duration] values are within [min, max], exponentially increasing and slightly randomized.

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -1,0 +1,46 @@
+package backoff
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestNewExponentialWithJitter(t *testing.T) {
+	tests := []struct {
+		name string
+		min  time.Duration
+		max  time.Duration
+	}{
+		{"defaults", 100 * time.Millisecond, 10 * time.Second},
+		{"small-values", time.Millisecond, time.Second},
+		{"huge-values", time.Minute, time.Hour},
+		{"small-range", time.Millisecond, 2 * time.Millisecond},
+		{"huge-range", time.Millisecond, time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewExponentialWithJitter(tt.min, tt.max)
+
+			// Ensure that multiple calls don't breach the upper bound
+			maxCounter := 0
+
+			for i := uint64(0); ; i++ {
+				if maxCounter >= 10 {
+					break
+				}
+				if i > 1_000_000 {
+					t.Error("not reached max")
+				}
+
+				d := r(i)
+				require.GreaterOrEqual(t, d, tt.min)
+				require.LessOrEqual(t, d, tt.max)
+
+				if d == tt.max {
+					maxCounter++
+				}
+			}
+		})
+	}
+}

--- a/database/db.go
+++ b/database/db.go
@@ -481,7 +481,7 @@ func (db *DB) BulkExec(
 							return nil
 						},
 						retry.Retryable,
-						backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+						backoff.DefaultBackoff,
 						db.GetDefaultRetrySettings(),
 					)
 				}
@@ -546,7 +546,7 @@ func (db *DB) NamedBulkExec(
 								return nil
 							},
 							retry.Retryable,
-							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+							backoff.DefaultBackoff,
 							db.GetDefaultRetrySettings(),
 						)
 					}
@@ -623,7 +623,7 @@ func (db *DB) NamedBulkExecTx(
 								return nil
 							},
 							retry.Retryable,
-							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+							backoff.DefaultBackoff,
 							db.GetDefaultRetrySettings(),
 						)
 					}
@@ -868,7 +868,7 @@ func (db *DB) HasTable(ctx context.Context, table string) (bool, error) {
 			return rows.Close()
 		},
 		retry.Retryable,
-		backoff.NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute),
+		backoff.DefaultBackoff,
 		db.GetDefaultRetrySettings())
 	if err != nil {
 		return false, errors.Wrapf(err, "can't verify existence of database table %q", table)

--- a/database/driver.go
+++ b/database/driver.go
@@ -59,7 +59,7 @@ func (c RetryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			return
 		},
 		retry.Retryable,
-		backoff.NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute),
+		backoff.DefaultBackoff,
 		retry.Settings{
 			Timeout: retry.DefaultTimeout,
 			OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {

--- a/redis/client.go
+++ b/redis/client.go
@@ -307,7 +307,7 @@ func dialWithLogging(dialer ctxDialerFunc, logger *logging.Logger) ctxDialerFunc
 				return
 			},
 			retry.Retryable,
-			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+			backoff.DefaultBackoff,
 			retry.Settings{
 				Timeout: retry.DefaultTimeout,
 				OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {


### PR DESCRIPTION
    backoff.NewExponentialWithJitter: Ensure bounds

    Ensure that the values generated by backoff.NewExponentialWithJitter are
    always within [min, max].

    While the old function documentation somewhat implied that min would be
    an infimum, the smallest possible value would be within [min/2, min) due
    to the internal jitter call. Thus, the first Backoff call would always
    return a value smaller than min.

    Both the documentation and the implementation was slightly changed,
    resulting in all durations to be within [min, max].

    To ensure this works as intended, a test case was written.

---

    backoff.DefaultBackoff: Introduce default value

    A common default backoff value was added to be used throughout the code.

    Prior, there were multiple calls to backoff.NewExponentialWithJitter
    with slightly different parameters, sometimes retrying ridiculously low
    durations. This common value should unify the retry logic.

    Fixes #132.

---

Fixes #132.