### PR TITLE
retry: Remove ResetTimeout function

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -121,18 +121,6 @@ func WithBackoff(
 	}
 }
 
-// ResetTimeout changes the possibly expired timer t to expire after duration d.
-//
-// If the timer has already expired and nothing has been received from its channel,
-// it is automatically drained as if the timer had never expired.
-func ResetTimeout(t *time.Timer, d time.Duration) {
-	if !t.Stop() {
-		<-t.C
-	}
-
-	t.Reset(d)
-}
-
 // Retryable returns true for common errors that are considered retryable,
 // i.e. temporary, timeout, DNS, connection refused and reset, host down and unreachable and
 // network down and unreachable errors. In addition, any database error is considered retryable.


### PR DESCRIPTION
Drop the unused and potentially faulty retry.ResetTimeout function.

The retry.ResetTimeout function relied that the time.Timer's internal channel is asynchronous. This behavior changed with Go 1.23, resulting in a now blocking t.C call[^0].

Since there is no usage of this function anymore[^1][^2] and the current implementation is error prone, it was removed.

```
$ for i in icinga{db,-notifications,-kubernetes}; do pushd $i; git pull; git grep ResetTimeout | wc -l; popd; done
~/git/github.com/Icinga/icingadb ~/git/github.com/Icinga
Already up to date.
0
~/git/github.com/Icinga
~/git/github.com/Icinga/icinga-notifications ~/git/github.com/Icinga
Already up to date.
0
~/git/github.com/Icinga
~/git/github.com/Icinga/icinga-kubernetes ~/git/github.com/Icinga
Already up to date.
0
~/git/github.com/Icinga
```

[^0]: https://pkg.go.dev/time#NewTimer
[^1]: https://github.com/Icinga/icingadb/issues/990
[^2]: https://github.com/Icinga/icingadb/commit/fead08e3e7d5e6277a3aa39878e6de03a5c4907a