### PR TITLE
redis.NewClientFromConfig(): remove obsolete workaround

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -76,7 +76,6 @@ func NewClientFromConfig(c *Config, logger *logging.Logger) (*Client, error) {
 	client := redis.NewClient(options)
 	options = client.Options()
 	options.PoolSize = max(32, options.PoolSize)
-	options.MaxRetries = options.PoolSize + 1 // https://github.com/go-redis/redis/issues/1737
 
 	return NewClient(redis.NewClient(options), logger, &c.Options), nil
 }


### PR DESCRIPTION
The underlying Redis client library doesn't blindly use eventually broken connections from the pool anymore. Hence, we don't have to re-try commands more often than the pool size.