### PR TITLE
notifications: drop obsolete event fields & introduce new ones

### DIFF
--- a/notifications/event/event.go
+++ b/notifications/event/event.go
@@ -27,9 +27,6 @@ type Event struct {
 	// For hosts: {"host": "host_name"} and for services: {"host": "host_name", "service": "service_name"}.
 	Tags map[string]string `json:"tags"`
 
-	// ExtraTags supplement Tags, for example with host or service groups for an Icinga DB source.
-	ExtraTags map[string]string `json:"extra_tags"`
-
 	// Type indicates the type of the event.
 	Type Type `json:"type"`
 	// Severity of the event.
@@ -52,10 +49,6 @@ type Event struct {
 	// as Icinga Notifications requires a reason for muting an object. Otherwise, it will be omitted
 	// from the encoded JSON.
 	MuteReason string `json:"mute_reason,omitempty"`
-
-	// RulesVersion and RuleIds are the source rules matching for this Event.
-	RulesVersion string   `json:"rules_version"`
-	RuleIds      []string `json:"rule_ids"`
 
 	// CompleteRelations contains a list of relations that should be considered complete for this event.
 	//

--- a/notifications/event/event.go
+++ b/notifications/event/event.go
@@ -56,4 +56,21 @@ type Event struct {
 	// RulesVersion and RuleIds are the source rules matching for this Event.
 	RulesVersion string   `json:"rules_version"`
 	RuleIds      []string `json:"rule_ids"`
+
+	// CompleteRelations contains a list of relations that should be considered complete for this event.
+	//
+	// Typically, when Icinga Notifications determines that the event didn't provide complete information
+	// needed to evaluate the rules in the [Relations] field, it will instruct the source to provide the
+	// missing information in a follow-up request. This field can be used by the source to indicate that
+	// it already provided all the available information it has for the certain relations and that the
+	// Icinga Notifications should not ask for more information for these relations.
+	CompleteRelations []string `json:"complete_relations,omitempty"`
+
+	// Relations contains additional information about the relations of the object this event is referring to.
+	//
+	// This will be used to evaluate JSONPath expressions in the filter columns of the event rules.
+	// The structure of this field is flexible and can contain any information that might be relevant
+	// for the evaluation of the rules. It will not be used for anything else than evaluating the rules
+	// and will not be persisted to the database as well.
+	Relations map[string]any `json:"relations,omitempty"`
 }

--- a/notifications/event/event_test.go
+++ b/notifications/event/event_test.go
@@ -21,7 +21,6 @@ func TestEvent(t *testing.T) {
 				Name:              "TestEvent",
 				URL:               "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
 				Tags:              map[string]string{"tag1": "value1"},
-				ExtraTags:         map[string]string{},
 				Type:              TypeState,
 				Severity:          SeverityOK,
 				Username:          "testuser",
@@ -31,8 +30,6 @@ func TestEvent(t *testing.T) {
 					"relation1": "relation1",
 					"relation2": "relation2",
 				},
-				RulesVersion: "0x1",
-				RuleIds:      []string{"1", "2", "3", "6"},
 			}
 
 			data, err := json.Marshal(event)
@@ -43,15 +40,12 @@ func TestEvent(t *testing.T) {
 					"name":"TestEvent",
 					"url":"/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
 					"tags":{"tag1":"value1"},
-					"extra_tags":{},
 					"type":"state",
 					"severity":"ok",
 					"username":"testuser",
 					"message":"Test",
 					"complete_relations":["relation1", "relation2"],
-					"relations":{"relation1":"relation1","relation2":"relation2"},
-					"rules_version": "0x1",
-					"rule_ids": ["1", "2", "3", "6"]
+					"relations":{"relation1":"relation1","relation2":"relation2"}
 				}`
 			assert.JSONEq(t, expected, string(data), "JSON encoding does not match expected output")
 		})

--- a/notifications/event/event_test.go
+++ b/notifications/event/event_test.go
@@ -18,14 +18,19 @@ func TestEvent(t *testing.T) {
 			t.Parallel()
 
 			event := &Event{
-				Name:         "TestEvent",
-				URL:          "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
-				Tags:         map[string]string{"tag1": "value1"},
-				ExtraTags:    map[string]string{},
-				Type:         TypeState,
-				Severity:     SeverityOK,
-				Username:     "testuser",
-				Message:      "Test",
+				Name:              "TestEvent",
+				URL:               "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
+				Tags:              map[string]string{"tag1": "value1"},
+				ExtraTags:         map[string]string{},
+				Type:              TypeState,
+				Severity:          SeverityOK,
+				Username:          "testuser",
+				Message:           "Test",
+				CompleteRelations: []string{"relation1", "relation2"},
+				Relations: map[string]any{
+					"relation1": "relation1",
+					"relation2": "relation2",
+				},
 				RulesVersion: "0x1",
 				RuleIds:      []string{"1", "2", "3", "6"},
 			}
@@ -43,6 +48,8 @@ func TestEvent(t *testing.T) {
 					"severity":"ok",
 					"username":"testuser",
 					"message":"Test",
+					"complete_relations":["relation1", "relation2"],
+					"relations":{"relation1":"relation1","relation2":"relation2"},
 					"rules_version": "0x1",
 					"rule_ids": ["1", "2", "3", "6"]
 				}`

--- a/notifications/http_headers.go
+++ b/notifications/http_headers.go
@@ -1,0 +1,10 @@
+package notifications
+
+// XIcingaRejectIfRelationsIncomplete is a custom HTTP header that can be used by sources to indicate that Icinga
+// Notifications should reject the request if the event's relations are incomplete.
+//
+// By default, Icinga Notifications will attempt to process events even if their relations are incomplete,
+// which may not be desirable in some cases. If a source sets this header to "true", Icinga Notifications
+// rejects the request with all the missing relations in the response body, allowing the source to retry
+// with the complete set of relations.
+const XIcingaRejectIfRelationsIncomplete = "X-Icinga-Reject-If-Relations-Incomplete"


### PR DESCRIPTION
> [!WARNING]
>
> This PR is not yet part of the main branch since it introduces a breaking change to the notifications package and all its users must be fixed first before merging this into the main branch (See the failing GHAs below).

This PR drops the obsolete `extra_tags`, `rule_ids`, and `rules_version` fields from the notification `Event` struct as they are no longer used by Icinga Notifications since https://github.com/Icinga/icinga-notifications/pull/418. It also introduces two new fields `complete_relations` and `relations` to the `Event` struct, which are going to be used by the new Notifications rule evaluation engine to determine which rules match a given event. Additionally, it adds a new HTTP header `X-Icinga-Reject-If-Relations-Incomplete` to be used by the Notifications API to indicate whether the client supports attribute negotiation. The name of the header is not final and is open for discussion.