### PR TITLE
notifications/plugin: remove `extra_tags` leftovers

### DIFF
--- a/notifications/plugin/plugin.go
+++ b/notifications/plugin/plugin.go
@@ -141,9 +141,6 @@ type Object struct {
 
 	// Tags defining this Object, may be "host" and "service" when from Icinga 2.
 	Tags map[string]string `json:"tags"`
-
-	// ExtraTags attached, may be a host or service groups when form Icinga 2.
-	ExtraTags map[string]string `json:"extra_tags"`
 }
 
 // Incident of this NotificationRequest, grouping Events for this Object.
@@ -311,13 +308,6 @@ func FormatMessage(writer io.Writer, req *NotificationRequest) {
 	_, _ = writer.Write([]byte("Tags:\n"))
 	for k, v := range utils.IterateOrderedMap(req.Object.Tags) {
 		_, _ = fmt.Fprintf(writer, "%s: %s\n", k, v)
-	}
-
-	if len(req.Object.ExtraTags) > 0 {
-		_, _ = writer.Write([]byte("\nExtra Tags:\n"))
-		for k, v := range utils.IterateOrderedMap(req.Object.ExtraTags) {
-			_, _ = fmt.Fprintf(writer, "%s: %s\n", k, v)
-		}
 	}
 
 	if req.Incident != nil {


### PR DESCRIPTION
> [!WARNING]
>
> This PR is not yet part of the main branch since it introduces a breaking change to the notifications package and all its users must be fixed first before merging this into the main branch (See the failing GHAs below).

Removes a leftover from #199.