### PR TITLE
notifications.source: Configurable relations

### DIFF
--- a/notifications/source/config.go
+++ b/notifications/source/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	// Password is the API user's password for the Icinga Notifications API.
 	Password     string `yaml:"password" env:"PASSWORD,unset"` // #nosec G117 -- exported password field
 	PasswordFile string `yaml:"password_file" env:"PASSWORD_FILE"`
+
+	// DefaultRelations to always resolve and include in the events submitted to Icinga Notifications.
+	DefaultRelations []string `yaml:"default_relations" env:"DEFAULT_RELATIONS"`
 }
 
 // Validate the configuration, implements config.Validator.

--- a/notifications/source/config_test.go
+++ b/notifications/source/config_test.go
@@ -53,6 +53,30 @@ password_file: %s`, passwordFile),
 				PasswordFile: passwordFile,
 			},
 		},
+		{
+			Name: "Custom attribute negotiation",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+url: http://localhost:5680
+username: icinga
+password: secret
+default_relations:
+  - 'host.vars'
+  - 'services[*].vars'`,
+				Env: map[string]string{
+					"URL":               "http://localhost:5680",
+					"USERNAME":          "icinga",
+					"PASSWORD":          "secret",
+					"DEFAULT_RELATIONS": "host.vars,services[*].vars",
+				},
+			},
+			Expected: Config{
+				Url:              "http://localhost:5680",
+				Username:         "icinga",
+				Password:         "secret",
+				DefaultRelations: []string{"host.vars", "services[*].vars"},
+			},
+		},
 	}
 
 	t.Run("FromEnv", func(t *testing.T) {


### PR DESCRIPTION
> [!WARNING]
>
> This PR is not yet part of the main branch since it introduces a breaking change to the notifications package and all its users must be fixed first before merging this into the main branch (See the failing GHAs below).

Extend the Config struct to allow specifying default relations to always be used when submitting events.

---

This PR is required for changes in Icinga/icingadb#1120 to address the following requirement from Icinga/icingadb#1098.

> If Icinga DB is configured to always include particular relations, it can signal Icinga Notifications that these are complete and cannot be updated by using a request header: X-Icinga-Complete-Relations: host.vars, services[*].vars