### PR TITLE
config: skip `ServerTLS` validation if TLS is not enabled

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -192,6 +192,10 @@ type ServerTLS struct {
 
 // Validate checks the [ServerTLS] configuration for consistency and returns an error if the configuration is invalid.
 func (st *ServerTLS) Validate() error {
+	if !st.Enable {
+		return nil
+	}
+
 	switch cat := tls.ClientAuthType(st.ClientAuth); cat {
 	case tls.NoClientCert, tls.RequestClientCert, tls.RequireAnyClientCert:
 		// These ClientAuth types do not require a CA certificate to be configured,

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -366,7 +366,11 @@ func TestServerTLS_Validate(t *testing.T) {
 	}
 	require.NoError(t, st.Validate())
 
+	st.Enable = false
 	st.ClientAuth = TlsClientAuthType(tls.VerifyClientCertIfGiven)
+	require.NoError(t, st.Validate())
+
+	st.Enable = true
 	require.Error(t, st.Validate())
 	st.ClientAuth = TlsClientAuthType(tls.RequireAndVerifyClientCert)
 	require.Error(t, st.Validate())


### PR DESCRIPTION
Do not perform any `ServerTLS` config validation if TLS isn't enabled.