### PR TITLE
Icinga Notifications Development State

### DIFF
--- a/notifications/event/event.go
+++ b/notifications/event/event.go
@@ -27,9 +27,6 @@ type Event struct {
 	// For hosts: {"host": "host_name"} and for services: {"host": "host_name", "service": "service_name"}.
 	Tags map[string]string `json:"tags"`
 
-	// ExtraTags supplement Tags, for example with host or service groups for an Icinga DB source.
-	ExtraTags map[string]string `json:"extra_tags"`
-
 	// Type indicates the type of the event.
 	Type Type `json:"type"`
 	// Severity of the event.
@@ -52,10 +49,6 @@ type Event struct {
 	// as Icinga Notifications requires a reason for muting an object. Otherwise, it will be omitted
 	// from the encoded JSON.
 	MuteReason string `json:"mute_reason,omitempty"`
-
-	// RulesVersion and RuleIds are the source rules matching for this Event.
-	RulesVersion string   `json:"rules_version"`
-	RuleIds      []string `json:"rule_ids"`
 
 	// CompleteRelations contains a list of relations that should be considered complete for this event.
 	//

--- a/notifications/event/event.go
+++ b/notifications/event/event.go
@@ -56,4 +56,21 @@ type Event struct {
 	// RulesVersion and RuleIds are the source rules matching for this Event.
 	RulesVersion string   `json:"rules_version"`
 	RuleIds      []string `json:"rule_ids"`
+
+	// CompleteRelations contains a list of relations that should be considered complete for this event.
+	//
+	// Typically, when Icinga Notifications determines that the event didn't provide complete information
+	// needed to evaluate the rules in the [Relations] field, it will instruct the source to provide the
+	// missing information in a follow-up request. This field can be used by the source to indicate that
+	// it already provided all the available information it has for the certain relations and that the
+	// Icinga Notifications should not ask for more information for these relations.
+	CompleteRelations []string `json:"complete_relations,omitempty"`
+
+	// Relations contains additional information about the relations of the object this event is referring to.
+	//
+	// This will be used to evaluate JSONPath expressions in the filter columns of the event rules.
+	// The structure of this field is flexible and can contain any information that might be relevant
+	// for the evaluation of the rules. It will not be used for anything else than evaluating the rules
+	// and will not be persisted to the database as well.
+	Relations map[string]any `json:"relations,omitempty"`
 }

--- a/notifications/event/event.go
+++ b/notifications/event/event.go
@@ -55,8 +55,13 @@ type Event struct {
 	// Typically, when Icinga Notifications determines that the event didn't provide complete information
 	// needed to evaluate the rules in the [Relations] field, it will instruct the source to provide the
 	// missing information in a follow-up request. This field can be used by the source to indicate that
-	// it already provided all the available information it has for the certain relations and that the
-	// Icinga Notifications should not ask for more information for these relations.
+	// it already provided all the available information it has for the certain relations and that Icinga
+	// Notifications should not ask for more information for these relations.
+	//
+	// The relations must be specified as JSONPath expressions that match the structure of the [Relations] field.
+	// For example, if the [Relations] field contains a "host" field with some information about the customvars,
+	// the source can add `host.vars` or `host.vars.something` to this list to indicate that it already provided
+	// all the host's customvars or all the information about the `something` customvar.
 	CompleteRelations []string `json:"complete_relations,omitempty"`
 
 	// Relations contains additional information about the relations of the object this event is referring to.

--- a/notifications/event/event_test.go
+++ b/notifications/event/event_test.go
@@ -21,7 +21,6 @@ func TestEvent(t *testing.T) {
 				Name:              "TestEvent",
 				URL:               "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
 				Tags:              map[string]string{"tag1": "value1"},
-				ExtraTags:         map[string]string{},
 				Type:              TypeState,
 				Severity:          SeverityOK,
 				Username:          "testuser",
@@ -31,8 +30,6 @@ func TestEvent(t *testing.T) {
 					"relation1": "relation1",
 					"relation2": "relation2",
 				},
-				RulesVersion: "0x1",
-				RuleIds:      []string{"1", "2", "3", "6"},
 			}
 
 			data, err := json.Marshal(event)
@@ -43,15 +40,12 @@ func TestEvent(t *testing.T) {
 					"name":"TestEvent",
 					"url":"/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
 					"tags":{"tag1":"value1"},
-					"extra_tags":{},
 					"type":"state",
 					"severity":"ok",
 					"username":"testuser",
 					"message":"Test",
 					"complete_relations":["relation1", "relation2"],
-					"relations":{"relation1":"relation1","relation2":"relation2"},
-					"rules_version": "0x1",
-					"rule_ids": ["1", "2", "3", "6"]
+					"relations":{"relation1":"relation1","relation2":"relation2"}
 				}`
 			assert.JSONEq(t, expected, string(data), "JSON encoding does not match expected output")
 		})

--- a/notifications/event/event_test.go
+++ b/notifications/event/event_test.go
@@ -18,14 +18,19 @@ func TestEvent(t *testing.T) {
 			t.Parallel()
 
 			event := &Event{
-				Name:         "TestEvent",
-				URL:          "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
-				Tags:         map[string]string{"tag1": "value1"},
-				ExtraTags:    map[string]string{},
-				Type:         TypeState,
-				Severity:     SeverityOK,
-				Username:     "testuser",
-				Message:      "Test",
+				Name:              "TestEvent",
+				URL:               "/icingadb/service?name=https%20ssl%20v3.0%20compatibility%20IE%206.0&host.name=example%20host",
+				Tags:              map[string]string{"tag1": "value1"},
+				ExtraTags:         map[string]string{},
+				Type:              TypeState,
+				Severity:          SeverityOK,
+				Username:          "testuser",
+				Message:           "Test",
+				CompleteRelations: []string{"relation1", "relation2"},
+				Relations: map[string]any{
+					"relation1": "relation1",
+					"relation2": "relation2",
+				},
 				RulesVersion: "0x1",
 				RuleIds:      []string{"1", "2", "3", "6"},
 			}
@@ -43,6 +48,8 @@ func TestEvent(t *testing.T) {
 					"severity":"ok",
 					"username":"testuser",
 					"message":"Test",
+					"complete_relations":["relation1", "relation2"],
+					"relations":{"relation1":"relation1","relation2":"relation2"},
 					"rules_version": "0x1",
 					"rule_ids": ["1", "2", "3", "6"]
 				}`

--- a/notifications/http_headers.go
+++ b/notifications/http_headers.go
@@ -1,0 +1,10 @@
+package notifications
+
+// XIcingaRejectIfRelationsIncomplete is a custom HTTP header that can be used by sources to indicate that Icinga
+// Notifications should reject the request if the event's relations are incomplete.
+//
+// By default, Icinga Notifications will attempt to process events even if their relations are incomplete,
+// which may not be desirable in some cases. If a source sets this header to "true", Icinga Notifications
+// rejects the request with all the missing relations in the response body, allowing the source to retry
+// with the complete set of relations.
+const XIcingaRejectIfRelationsIncomplete = "X-Icinga-Reject-If-Relations-Incomplete"

--- a/notifications/plugin/plugin.go
+++ b/notifications/plugin/plugin.go
@@ -141,9 +141,6 @@ type Object struct {
 
 	// Tags defining this Object, may be "host" and "service" when from Icinga 2.
 	Tags map[string]string `json:"tags"`
-
-	// ExtraTags attached, may be a host or service groups when form Icinga 2.
-	ExtraTags map[string]string `json:"extra_tags"`
 }
 
 // Incident of this NotificationRequest, grouping Events for this Object.
@@ -311,13 +308,6 @@ func FormatMessage(writer io.Writer, req *NotificationRequest) {
 	_, _ = writer.Write([]byte("Tags:\n"))
 	for k, v := range utils.IterateOrderedMap(req.Object.Tags) {
 		_, _ = fmt.Fprintf(writer, "%s: %s\n", k, v)
-	}
-
-	if len(req.Object.ExtraTags) > 0 {
-		_, _ = writer.Write([]byte("\nExtra Tags:\n"))
-		for k, v := range utils.IterateOrderedMap(req.Object.ExtraTags) {
-			_, _ = fmt.Fprintf(writer, "%s: %s\n", k, v)
-		}
 	}
 
 	if req.Incident != nil {

--- a/notifications/source/client.go
+++ b/notifications/source/client.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/icinga/icinga-go-library/notifications"
 	"github.com/icinga/icinga-go-library/notifications/event"
 	"github.com/pkg/errors"
 )
@@ -71,41 +73,14 @@ func NewClient(cfg Config, clientName string) (*Client, error) {
 	}, nil
 }
 
-// RulesInfo holds information about the event rules for a specific source.
-//
-// A Client can fetch RulesInfo from the Icinga Notifications API via Client.ProcessEvent.
-//
-// The Version represents the current rules version for this Client. This value should be stored by a caller and set to
-// [event.Event.EventVersion] when being passed to Client.ProcessEvent, as described there. This allows detecting
-// outdated source rules.
-//
-// Rules is a map of rule IDs to object filter expressions. These object filter expressions are source-specific. For
-// example, Icinga DB expects an SQL query.
-type RulesInfo struct {
-	// Version of the event rules fetched from the API.
-	Version string
-
-	// Rules is a map of rule IDs to their corresponding object filter expression.
-	Rules map[string]string
-}
-
-// ErrRulesOutdated implies that the rules version between the submitted event and Icinga Notifications mismatches.
-var ErrRulesOutdated = stderrors.New("rules version is outdated")
+// ErrAttrsNegotiation implies missing attributes.
+var ErrAttrsNegotiation = stderrors.New("attribute negotiation required")
 
 // ProcessEvent submits an event.Event to the Icinga Notifications /process-event API endpoint.
 //
-// For a successful submission, this method returns (nil, nil).
-//
-// It may return an ErrRulesOutdated error, implying that the provided ruleVersion does not match the current rules
-// version in the Icinga Notifications daemon. Only in this case, it will also return the current rules specific to this
-// source and their version as RulesInfo, allowing to retry submitting an event after reevaluating it.
-//
-// For the Event to be submitted, Event.RulesVersion and Event.RuleIds should be set. If no appropriate values are
-// known, they can be left empty. This will return ErrRulesOutdated - unless there are no rules configured that need to
-// be evaluated by the source -, which can be handled as described above to retrieve information and resubmit the event.
-//
-// If the request fails or the response is not as expected, it returns an error.
-func (client *Client) ProcessEvent(ctx context.Context, ev *event.Event) (*RulesInfo, error) {
+// When rejectIncompete is set and the returned error is ErrAttrsNegotiation,
+// the first return parameter is an array of required attributes.
+func (client *Client) ProcessEvent(ctx context.Context, ev *event.Event, rejectIncompete bool) ([]string, error) {
 	body, err := json.Marshal(ev)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot encode event to JSON")
@@ -118,6 +93,7 @@ func (client *Client) ProcessEvent(ctx context.Context, ev *event.Event) (*Rules
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
+	req.Header.Add(notifications.XIcingaRejectIfRelationsIncomplete, fmt.Sprintf("%t", rejectIncompete))
 
 	resp, err := client.httpClient.Do(req) // #nosec G704 -- SSRF impossible, trusted user input
 	if err != nil {
@@ -129,16 +105,14 @@ func (client *Client) ProcessEvent(ctx context.Context, ev *event.Event) (*Rules
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode == http.StatusPreconditionFailed {
-		// Indicates that the rules version is outdated and the body should contain the current rules and their version.
-		// So, we read the body to extract the rules and return an ErrRulesOutdated error, so the caller can retry
-		// the event submission after it has reevaluated them.
-		var rulesInfo RulesInfo
-		if err := json.NewDecoder(resp.Body).Decode(&rulesInfo); err != nil {
-			return nil, errors.Wrap(err, "cannot decode new rules from process event response")
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		var attributeNegotiationResp struct{ Attributes []string }
+
+		if err := json.NewDecoder(resp.Body).Decode(&attributeNegotiationResp); err != nil {
+			return nil, errors.Wrap(err, "cannot decode attribute negotiation from process event response")
 		}
 
-		return &rulesInfo, ErrRulesOutdated
+		return attributeNegotiationResp.Attributes, ErrAttrsNegotiation
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode <= 299 {

--- a/notifications/source/config.go
+++ b/notifications/source/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	// Password is the API user's password for the Icinga Notifications API.
 	Password     string `yaml:"password" env:"PASSWORD,unset"` // #nosec G117 -- exported password field
 	PasswordFile string `yaml:"password_file" env:"PASSWORD_FILE"`
+
+	// DefaultRelations to always resolve and include in the events submitted to Icinga Notifications.
+	DefaultRelations []string `yaml:"default_relations" env:"DEFAULT_RELATIONS"`
 }
 
 // Validate the configuration, implements config.Validator.

--- a/notifications/source/config_test.go
+++ b/notifications/source/config_test.go
@@ -53,6 +53,30 @@ password_file: %s`, passwordFile),
 				PasswordFile: passwordFile,
 			},
 		},
+		{
+			Name: "Custom attribute negotiation",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+url: http://localhost:5680
+username: icinga
+password: secret
+default_relations:
+  - 'host.vars'
+  - 'services[*].vars'`,
+				Env: map[string]string{
+					"URL":               "http://localhost:5680",
+					"USERNAME":          "icinga",
+					"PASSWORD":          "secret",
+					"DEFAULT_RELATIONS": "host.vars,services[*].vars",
+				},
+			},
+			Expected: Config{
+				Url:              "http://localhost:5680",
+				Username:         "icinga",
+				Password:         "secret",
+				DefaultRelations: []string{"host.vars", "services[*].vars"},
+			},
+		},
 	}
 
 	t.Run("FromEnv", func(t *testing.T) {


### PR DESCRIPTION
With https://github.com/Icinga/icingadb/pull/1120 and https://github.com/Icinga/icinga-notifications/pull/418 being merged, the `HEAD` of both Icinga DB and Icinga Notifications are now requiring the IGL's `develop` branch - as the failing CI in #207 highlights. So, we can merge this now into `main`.

Includes:
- #199
- #201
- #202
- #203
- #205