### PR TITLE
GHA: Exclude Icinga for K8s from Compatibility

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -17,7 +17,8 @@ jobs:
         downstream:
           - { name: "Icinga DB",             repo: "Icinga/icingadb" }
           - { name: "Icinga Notifications",  repo: "Icinga/icinga-notifications" }
-          - { name: "Icinga for Kubernetes", repo: "Icinga/icinga-kubernetes" }
+          # Exclude until the latest Icinga Notifications changes are applied.
+          # - { name: "Icinga for Kubernetes", repo: "Icinga/icinga-kubernetes" }
 
     steps:
       - name: Setup Go


### PR DESCRIPTION
The latest Icinga Notifications changes were breaking and require manual intervention, as done for Icinga DB and Icinga Notifications. Later, these changes will also be made for Icinga for Kubernetes. Until then, it will be excluded from the CI to have green workflows.