### PR TITLE
database: Add TxOptions to DB.ExecTx

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -820,13 +820,15 @@ func (db *DB) Delete(
 // Starts a new transaction, executes the provided function, and commits the transaction
 // if the function succeeds. If the function returns an error, the transaction is rolled back.
 //
+// Transaction options can be specified, for example, to specify an isolation level. Otherwise, it can be left as nil.
+//
 // Returns an error if starting the transaction, executing the function, or committing the transaction fails.
 //
 // Note that committing the transaction may not honor the context provided. For some database drivers, once a COMMIT
 // query is started, it will block until the database responds. Therefore, for time-critical scenarios, it is
 // recommended to add a select wrapper against the context.
-func (db *DB) ExecTx(ctx context.Context, fn func(context.Context, *sqlx.Tx) error) error {
-	tx, err := db.BeginTxx(ctx, nil)
+func (db *DB) ExecTx(ctx context.Context, opts *sql.TxOptions, fn func(context.Context, *sqlx.Tx) error) error {
+	tx, err := db.BeginTxx(ctx, opts)
 	if err != nil {
 		return errors.Wrap(err, "can't start transaction")
 	}


### PR DESCRIPTION
Expose the sql.TxOptions parameter from DB.BeginTxx to DB.ExecTx callers. In most cases, the default "nil" will be enough, but there are multiple cases were a nonstandard isolation level is desired.

While this is an API breakage, the DB.ExecTx method is not much used, making this an easy fix.

---

This change is required in https://github.com/Icinga/icinga-notifications/pull/443 as I don't wanted to repeat myself over there or reintroduce this as a local utility function.

Downstream PRs:
- https://github.com/Icinga/icingadb/pull/1136
- https://github.com/Icinga/icinga-notifications/pull/449