### PR TITLE
add CRL-based client certificate revocation check

### DIFF
--- a/config/crl.go
+++ b/config/crl.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"go.uber.org/zap"
+)
+
+// CrlChecker loads a Certificate Revocation List (CRL) from a file, verifies its signature
+// against a trusted CA certificate, and exposes [CrlChecker.IsRevoked] for serial number
+// lookups. The in-memory CRL is protected by a read/write mutex so that background reloads
+// via [CrlChecker.WatchAndReload] are safe to run concurrently with ongoing checks.
+type CrlChecker struct {
+	mu         sync.RWMutex
+	path       string
+	issuer     *x509.Certificate
+	crlExpiry  time.Time
+	crlRevoked map[string]struct{}
+}
+
+// NewCRLChecker creates a [CrlChecker] by loading the CRL at path and verifying its signature
+// against issuer. The file may be PEM- or DER-encoded. An error is returned if the file cannot
+// be read, is not a valid CRL, or its signature does not match issuer.
+func NewCRLChecker(path string, issuer *x509.Certificate) (*CrlChecker, error) {
+	c := &CrlChecker{path: path, issuer: issuer}
+	if err := c.reload(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// reload reads the CRL file, verifies its signature against the issuer, and updates the in-memory CRL.
+func (c *CrlChecker) reload() error {
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		return fmt.Errorf("cannot read CRL file: %w", err)
+	}
+	if block, _ := pem.Decode(data); block != nil {
+		data = block.Bytes // strip PEM wrapper if present; ParseRevocationList wants DER
+	}
+	rl, err := x509.ParseRevocationList(data)
+	if err != nil {
+		return fmt.Errorf("cannot parse CRL: %w", err)
+	}
+
+	err = rl.CheckSignatureFrom(c.issuer)
+	if err != nil {
+		return fmt.Errorf("CRL signature invalid: %w", err)
+	}
+
+	revoked := make(map[string]struct{})
+	for _, entry := range rl.RevokedCertificateEntries {
+		revoked[entry.SerialNumber.Text(16)] = struct{}{}
+	}
+
+	c.mu.Lock()
+	c.crlExpiry = rl.NextUpdate
+	c.crlRevoked = revoked
+	c.mu.Unlock()
+
+	return nil
+}
+
+// WatchAndReload blocks, watching the CRL file for changes and reloading it whenever a
+// Write, Create, or Rename event is received. It returns when ctx is canceled.
+// Reload failures are logged as warnings and do not stop the watcher.
+func (c *CrlChecker) WatchAndReload(ctx context.Context, logger *zap.SugaredLogger) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("cannot create watcher: %w", err)
+	}
+	defer func() { _ = watcher.Close() }()
+	if err := watcher.Add(filepath.Dir(c.path)); err != nil {
+		return fmt.Errorf("cannot watch CRL file: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return fmt.Errorf("CRL watcher channel closed unexpectedly")
+			}
+
+			if filepath.Base(event.Name) != filepath.Base(c.path) {
+				continue
+			}
+
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+				if err := c.reload(); err != nil {
+					logger.Warnw("CRL reload failed", zap.Error(err))
+				} else {
+					logger.Info("CRL reloaded successfully")
+				}
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return fmt.Errorf("CRL watcher error channel closed unexpectedly")
+			}
+			logger.Warnw("CRL watcher error", zap.Error(err))
+		}
+	}
+}
+
+// IsRevoked reports whether serial appears in the CRL.
+//
+// It returns an error if the CRL is outdated (NextUpdate in the past).
+func (c *CrlChecker) IsRevoked(serial *big.Int) (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if time.Now().After(c.crlExpiry) {
+		return false, fmt.Errorf("CRL is outdated (NextUpdate=%s)", c.crlExpiry)
+	}
+
+	_, revoked := c.crlRevoked[serial.Text(16)]
+	return revoked, nil
+}

--- a/config/crl_test.go
+++ b/config/crl_test.go
@@ -1,0 +1,291 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func testCA(t *testing.T) (*x509.Certificate, crypto.PrivateKey) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+// buildCRL builds a CRL with the given parameters and returns its PEM-encoded bytes.
+func buildCRL(t *testing.T, ca *x509.Certificate, caKey crypto.PrivateKey, nextUpdate time.Time, revokedSerials ...*big.Int) []byte {
+	entries := make([]x509.RevocationListEntry, 0, len(revokedSerials))
+	for _, s := range revokedSerials {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   s,
+			RevocationTime: time.Now().Add(-time.Hour),
+		})
+	}
+	template := &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-time.Hour),
+		NextUpdate:                nextUpdate,
+		RevokedCertificateEntries: entries,
+	}
+	signer, ok := caKey.(crypto.Signer)
+	require.True(t, ok, "caKey must implement crypto.Signer")
+	der, err := x509.CreateRevocationList(rand.Reader, template, ca, signer)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, pem.Encode(&buf, &pem.Block{Type: "X509 CRL", Bytes: der}))
+	return buf.Bytes()
+}
+
+// createCRLFile creates a temporary CRL file and returns its path.
+func createCRLFile(t *testing.T, ca *x509.Certificate, caKey crypto.PrivateKey, nextUpdate time.Time, revokedSerials ...*big.Int) string {
+	tmp, err := os.CreateTemp(t.TempDir(), "crl-*.pem")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+	_, err = tmp.Write(buildCRL(t, ca, caKey, nextUpdate, revokedSerials...))
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	return tmp.Name()
+}
+
+// atomicReplaceCRL writes a new CRL to a temp file then renames it over path,
+// mirroring the production mv-based CRL update that exercises the fsnotify re-add branch.
+func atomicReplaceCRL(t *testing.T, path string, ca *x509.Certificate, caKey crypto.PrivateKey, nextUpdate time.Time, revokedSerials ...*big.Int) {
+	_ = os.Remove(path)
+	tmp, err := os.CreateTemp(filepath.Dir(path), "crl-new-*.pem")
+	require.NoError(t, err)
+	_, err = tmp.Write(buildCRL(t, ca, caKey, nextUpdate, revokedSerials...))
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	require.NoError(t, os.Rename(tmp.Name(), path))
+
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestNewCRLChecker(t *testing.T) {
+	ca, caKey := testCA(t)
+	future := time.Now().Add(24 * time.Hour)
+
+	t.Run("Valid PEM CRL", func(t *testing.T) {
+		path := createCRLFile(t, ca, caKey, future)
+		checker, err := NewCRLChecker(path, ca)
+		require.NoError(t, err)
+		require.NotNil(t, checker)
+	})
+
+	t.Run("Valid DER CRL", func(t *testing.T) {
+		template := &x509.RevocationList{
+			Number:     big.NewInt(1),
+			ThisUpdate: time.Now().Add(-time.Hour),
+			NextUpdate: future,
+		}
+		signer, ok := caKey.(crypto.Signer)
+		require.True(t, ok, "caKey must implement crypto.Signer")
+		der, err := x509.CreateRevocationList(rand.Reader, template, ca, signer)
+		require.NoError(t, err)
+		f, err := os.CreateTemp(t.TempDir(), "crl-*.der")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(der)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		checker, err := NewCRLChecker(f.Name(), ca)
+		require.NoError(t, err)
+		require.NotNil(t, checker)
+	})
+
+	t.Run("Nonexistent file", func(t *testing.T) {
+		_, err := NewCRLChecker("/nonexistent/crl.pem", ca)
+		require.ErrorContains(t, err, "cannot read CRL file")
+	})
+
+	t.Run("Corrupt data", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "crl-*.pem")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write([]byte("not a crl"))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		_, err = NewCRLChecker(f.Name(), ca)
+		require.ErrorContains(t, err, "cannot parse CRL")
+	})
+
+	t.Run("Wrong CA signature", func(t *testing.T) {
+		otherCA, otherKey := testCA(t)
+		path := createCRLFile(t, otherCA, otherKey, future)
+		_, err := NewCRLChecker(path, ca)
+		require.ErrorContains(t, err, "CRL signature invalid")
+	})
+}
+
+func TestCRLChecker_IsRevoked(t *testing.T) {
+	ca, caKey := testCA(t)
+	revokedSerial := big.NewInt(42)
+	validSerial := big.NewInt(43)
+	future := time.Now().Add(24 * time.Hour)
+
+	path := createCRLFile(t, ca, caKey, future, revokedSerial)
+	checker, err := NewCRLChecker(path, ca)
+	require.NoError(t, err)
+
+	t.Run("Revoked serial", func(t *testing.T) {
+		revoked, err := checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+	})
+
+	t.Run("Non-revoked serial", func(t *testing.T) {
+		revoked, err := checker.IsRevoked(validSerial)
+		require.NoError(t, err)
+		require.False(t, revoked)
+	})
+
+	t.Run("Expired CRL", func(t *testing.T) {
+		// Must be after ThisUpdate (-1h) but before now so the expiry branch triggers.
+		past := time.Now().Add(-30 * time.Minute)
+
+		// Build checker with expired CRL that contains revokedSerial.
+		expiredPath := createCRLFile(t, ca, caKey, past, revokedSerial)
+		expiredChecker, err := NewCRLChecker(expiredPath, ca)
+		require.NoError(t, err)
+
+		// Replace with an expired CRL that no longer lists revokedSerial.
+		atomicReplaceCRL(t, expiredPath, ca, caKey, past)
+
+		// IsRevoked detects expiry, throws an error even though the serial is in the CRL.
+		_, err = expiredChecker.IsRevoked(revokedSerial)
+		require.ErrorContains(t, err, "CRL is outdated (NextUpdate=")
+	})
+}
+
+func TestCRLChecker_WatchAndReload(t *testing.T) {
+	ca, caKey := testCA(t)
+	revokedSerial := big.NewInt(42)
+	future := time.Now().Add(24 * time.Hour)
+	logger := zaptest.NewLogger(t).Sugar()
+
+	t.Run("Reloads on atomic file replacement", func(t *testing.T) {
+		path := createCRLFile(t, ca, caKey, future, revokedSerial)
+		checker, err := NewCRLChecker(path, ca)
+		require.NoError(t, err)
+
+		revoked, err := checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go func() {
+			if err := checker.WatchAndReload(ctx, logger); err != nil {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+		}()
+		time.Sleep(1 * time.Second)
+
+		// Simulate production CRL rotation via atomic rename.
+		atomicReplaceCRL(t, path, ca, caKey, future)
+
+		revoked, err = checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.False(t, revoked)
+
+		atomicReplaceCRL(t, path, ca, caKey, future, revokedSerial)
+
+		revoked, err = checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+	})
+
+	t.Run("Deleted file fallback", func(t *testing.T) {
+		path := createCRLFile(t, ca, caKey, future, revokedSerial)
+		checker, err := NewCRLChecker(path, ca)
+		require.NoError(t, err)
+
+		revoked, err := checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go func() {
+			if err := checker.WatchAndReload(ctx, logger); err != nil {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		_ = os.Remove(path)
+
+		revoked, err = checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+	})
+
+	t.Run("Cached CRL file expires", func(t *testing.T) {
+		path := createCRLFile(t, ca, caKey, time.Now().Add(2*time.Second), revokedSerial)
+		checker, err := NewCRLChecker(path, ca)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go func() {
+			if err := checker.WatchAndReload(ctx, logger); err != nil {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+		}()
+		time.Sleep(100 * time.Millisecond)
+
+		revoked, err := checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+
+		_ = os.Remove(path)
+
+		revoked, err = checker.IsRevoked(revokedSerial)
+		require.NoError(t, err)
+		require.True(t, revoked)
+
+		require.Eventually(t, func() bool {
+			_, err := checker.IsRevoked(revokedSerial)
+			if err == nil {
+				return false
+			}
+			return strings.Contains(err.Error(), "CRL is outdated")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+}

--- a/config/tls.go
+++ b/config/tls.go
@@ -4,8 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"github.com/pkg/errors"
+	"fmt"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // TLSCommon represents common TLS config options that are shared between TLS client and server settings.
@@ -188,6 +190,20 @@ type ServerTLS struct {
 	// Valid values are all the [tls.ClientAuthType] options typed out as strings:
 	// "NoClientCert", "RequestClientCert", "RequireAnyClientCert", "VerifyClientCertIfGiven", and "RequireAndVerifyClientCert".
 	ClientAuth TlsClientAuthType `yaml:"client_auth" env:"CLIENT_AUTH" default:"NoClientCert"`
+
+	// CrlFile is the path to the Certificate Revocation List (CRL) file.
+	//
+	// If specified, the CRL is used to check for revoked certificates in TLS.
+	// The CRL must be signed by the CA specified in the Ca option. If the CRL file is not found or cannot be loaded,
+	// an error is returned during TLS configuration.
+	// This option is ignored if TLS is not enabled. If the Ca option is not set it returns an error.
+	//
+	// At the moment, only one CA certificate is supported.
+	//
+	// Note that populating this field alone does not enable CRL checking.
+	// [ServerTLS.InitRevocationChecking] must be called after assembling the [tls.Config]
+	// to wire up the actual revocation check.
+	CrlFile string `yaml:"crl_file" env:"CRL_FILE"`
 }
 
 // Validate checks the [ServerTLS] configuration for consistency and returns an error if the configuration is invalid.
@@ -198,6 +214,9 @@ func (st *ServerTLS) Validate() error {
 
 	switch cat := tls.ClientAuthType(st.ClientAuth); cat {
 	case tls.NoClientCert, tls.RequestClientCert, tls.RequireAnyClientCert:
+		if st.CrlFile != "" {
+			return errors.New("CRL file given, but given ClientAuth mode doesn't verify client certificates")
+		}
 		// These ClientAuth types do not require a CA certificate to be configured,
 		// since the server will not verify client certificates in these modes.
 		return nil
@@ -216,6 +235,9 @@ func (st *ServerTLS) Validate() error {
 // It returns a configured *tls.Config or an error if there are issues with the provided TLS settings.
 // If TLS is not enabled (st.Enable is false), it returns nil without an error.
 func (st *ServerTLS) MakeConfig() (*tls.Config, error) {
+	if st.CrlFile != "" && st.Ca == "" {
+		return nil, errors.New("CRL file given, but CA certificate missing")
+	}
 	tlsConfig, err := st.makeConfig()
 	if err != nil {
 		return nil, err
@@ -242,4 +264,76 @@ func (st *ServerTLS) MakeConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+// InitRevocationChecking wires CRL-based client certificate revocation checking into tlsConfig.
+//
+// It loads the CA certificate from [TLSCommon.Ca] and the CRL from [ServerTLS.CrlFile], verifies
+// the CRL's signature against the CA, and installs a [tls.Config.VerifyConnection] hook that
+// rejects any client certificate whose serial number appears in the CRL. If a VerifyConnection
+// hook is already set on tlsConfig, the existing hook is called first and its error, if any,
+// takes precedence.
+//
+// The returned [CrlChecker] owns the loaded CRL and must be kept alive for the duration
+// of the server's lifetime. Callers are responsible for calling [CrlChecker.WatchAndReload]
+// to pick up CRL rotations at runtime.
+//
+// InitRevocationChecking returns an error if tlsConfig, the CA certificate or CRL cannot be loaded or verified.
+func (st *ServerTLS) InitRevocationChecking(tlsConfig *tls.Config) (*CrlChecker, error) {
+	if tlsConfig == nil || st.CrlFile == "" || st.Ca == "" {
+		return nil, errors.New("tls config for crl is required")
+	}
+
+	caPem, err := loadPemOrFile(st.Ca)
+	if err != nil {
+		return nil, err
+	}
+
+	var caCerts []*x509.Certificate
+	rest := caPem
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		caCerts = append(caCerts, cert)
+	}
+	if len(caCerts) != 1 {
+		return nil, fmt.Errorf("expected one CA certificate in the CA bundle, got %d", len(caCerts))
+	}
+
+	checker, err := NewCRLChecker(st.CrlFile, caCerts[0])
+	if err != nil {
+		return nil, fmt.Errorf("cannot load CRL: %w", err)
+	}
+
+	existing := tlsConfig.VerifyConnection
+	tlsConfig.VerifyConnection = func(cs tls.ConnectionState) error {
+		if existing != nil {
+			if err := existing(cs); err != nil {
+				return err
+			}
+		}
+
+		if len(cs.VerifiedChains) == 0 {
+			return nil // no client cert presented - skip
+		}
+
+		leaf := cs.VerifiedChains[0][0]
+		revoked, err := checker.IsRevoked(leaf.SerialNumber)
+		if err != nil {
+			return fmt.Errorf("CRL check failed: %w", err)
+		} else if revoked {
+			return fmt.Errorf("client certificate revoked (serial %s)", leaf.SerialNumber)
+		}
+
+		return nil
+	}
+
+	return checker, nil
 }

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -10,13 +10,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"github.com/icinga/icinga-go-library/testutils"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/icinga/icinga-go-library/testutils"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_loadPemOrFile(t *testing.T) {
@@ -416,6 +417,112 @@ func TestTlsClientAuthType(t *testing.T) {
 	})
 }
 
+func TestTLSCommon_InitRevocationChecking(t *testing.T) {
+	ca, caKey, err := generateCert("ca", generateCertOptions{ca: true})
+	require.NoError(t, err)
+
+	var caPem bytes.Buffer
+	require.NoError(t, pem.Encode(&caPem, &pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw}))
+	caStr := caPem.String()
+
+	revokedCert, _, err := generateCert("revoked", generateCertOptions{issuer: ca, issuerKey: caKey})
+	require.NoError(t, err)
+	validCert, _, err := generateCert("valid", generateCertOptions{issuer: ca, issuerKey: caKey})
+	require.NoError(t, err)
+
+	nextUpdate := time.Now().Add(24 * time.Hour)
+	emptyCrlFile := createCRLFile(t, ca, caKey, nextUpdate)
+	revokedCrlFile := createCRLFile(t, ca, caKey, nextUpdate, revokedCert.SerialNumber)
+
+	t.Run("Nil tlsConfig", func(t *testing.T) {
+		st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: emptyCrlFile}
+		checker, err := st.InitRevocationChecking(nil)
+		require.ErrorContains(t, err, "tls config for crl is required")
+		require.Nil(t, checker)
+	})
+
+	t.Run("Empty CrlFile", func(t *testing.T) {
+		st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}}
+		checker, err := st.InitRevocationChecking(&tls.Config{})
+		require.ErrorContains(t, err, "tls config for crl is required")
+		require.Nil(t, checker)
+	})
+
+	t.Run("Empty Ca", func(t *testing.T) {
+		st := &ServerTLS{CrlFile: emptyCrlFile}
+		checker, err := st.InitRevocationChecking(&tls.Config{})
+		require.ErrorContains(t, err, "tls config for crl is required")
+		require.Nil(t, checker)
+	})
+
+	t.Run("Invalid Ca", func(t *testing.T) {
+		st := &ServerTLS{TLSCommon: TLSCommon{Ca: "/nonexistent/ca.pem"}, CrlFile: emptyCrlFile}
+		_, err := st.InitRevocationChecking(&tls.Config{})
+		require.Error(t, err)
+	})
+
+	t.Run("Nonexistent CRL file", func(t *testing.T) {
+		st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: "/nonexistent/crl.pem"}
+		_, err := st.InitRevocationChecking(&tls.Config{})
+		require.ErrorContains(t, err, "cannot load CRL")
+	})
+
+	t.Run("Valid CA and Valid CRL", func(t *testing.T) {
+		st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: emptyCrlFile}
+		tlsConf := &tls.Config{}
+		checker, err := st.InitRevocationChecking(tlsConf)
+		require.NoError(t, err)
+		require.NotNil(t, checker)
+		require.NotNil(t, tlsConf.VerifyConnection)
+	})
+
+	t.Run("VerifyConnection", func(t *testing.T) {
+		t.Run("Empty VerifiedChains", func(t *testing.T) {
+			st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: emptyCrlFile}
+			tlsConf := &tls.Config{}
+			_, err := st.InitRevocationChecking(tlsConf)
+			require.NoError(t, err)
+			require.NoError(t, tlsConf.VerifyConnection(tls.ConnectionState{}))
+		})
+
+		t.Run("Valid Cert", func(t *testing.T) {
+			st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: revokedCrlFile}
+			tlsConf := &tls.Config{}
+			_, err := st.InitRevocationChecking(tlsConf)
+			require.NoError(t, err)
+			err = tlsConf.VerifyConnection(tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{validCert}},
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("Revoked Cert", func(t *testing.T) {
+			st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: revokedCrlFile}
+			tlsConf := &tls.Config{}
+			_, err := st.InitRevocationChecking(tlsConf)
+			require.NoError(t, err)
+			err = tlsConf.VerifyConnection(tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{revokedCert}},
+			})
+			require.ErrorContains(t, err, "client certificate revoked")
+		})
+
+		t.Run("Chains existing VerifyConnection", func(t *testing.T) {
+			st := &ServerTLS{TLSCommon: TLSCommon{Ca: caStr}, CrlFile: emptyCrlFile}
+			sentinel := errors.New("existing verify error")
+			tlsConf := &tls.Config{
+				VerifyConnection: func(_ tls.ConnectionState) error { return sentinel },
+			}
+			_, err := st.InitRevocationChecking(tlsConf)
+			require.NoError(t, err)
+			err = tlsConf.VerifyConnection(tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{validCert}},
+			})
+			require.ErrorIs(t, err, sentinel)
+		})
+	})
+}
+
 type generateCertOptions struct {
 	ca        bool
 	issuer    *x509.Certificate
@@ -433,12 +540,17 @@ func generateCert(cn string, options generateCertOptions) (*x509.Certificate, cr
 		return nil, nil, err
 	}
 
+	keyUsage := x509.KeyUsageCertSign
+	if options.ca {
+		keyUsage |= x509.KeyUsageCRLSign
+	}
+
 	template := &x509.Certificate{
 		SerialNumber:          serialNumber,
 		Subject:               pkix.Name{CommonName: cn},
 		NotBefore:             time.Now().Add(-1 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign,
+		KeyUsage:              keyUsage,
 		BasicConstraintsValid: true,
 		IsCA:                  options.ca,
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/creasty/defaults v1.8.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/goccy/go-yaml v1.13.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=


### PR DESCRIPTION
Add a crlChecker that loads a PEM or DER Certificate Revocation List, verifies its signature against the CA, and watches the file for live updates via fsnotify. Atomic file replacements (mv) are handled by re-adding the watch path on Create/Rename events.

Expose ApplyRevocationCheck on TLSCommon, which wires the checker into tls.Config.VerifyConnection so revoked client certificates are rejected at handshake time.

resolves #218

refs https://github.com/Icinga/icinga-notifications/pull/454