### PR TITLE
DB: add support for column exclusion in `DB#BuildUpsertStmt`

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -348,10 +348,20 @@ func (db *DB) BuildUpdateStmt(update any) (string, int) {
 }
 
 // BuildUpsertStmt returns an upsert statement for the given struct.
-func (db *DB) BuildUpsertStmt(subject any) (stmt string, placeholders int) {
-	insertColumns := db.columnMap.Columns(subject)
+//
+// If the withoutColumns parameter is provided, the specified columns will be excluded from the insert and update
+// clauses. Note that if subject implements [Upserter], the update clause will be built from the columns of the
+// struct returned by [Upsert]() instead and the withoutColumns param won't have any effect on the update clause.
+func (db *DB) BuildUpsertStmt(subject any, withoutColumns ...string) (stmt string, placeholders int) {
 	table := TableName(subject)
-	var updateColumns []string
+	var insertColumns, updateColumns []string
+	if len(withoutColumns) > 0 {
+		insertColumns = slices.DeleteFunc(db.BuildColumns(subject), func(column string) bool {
+			return slices.Contains(withoutColumns, column)
+		})
+	} else {
+		insertColumns = db.columnMap.Columns(subject)
+	}
 
 	if upserter, ok := subject.(Upserter); ok {
 		updateColumns = db.columnMap.Columns(upserter.Upsert())


### PR DESCRIPTION
Just like the existing `BuildInsertStmtWithout` auxiliary function, the `DB#BuildUpsertStmt` function now also supports to exclude columns from the generated upsert query. However, as opposed to the `BuildInsertStmtWithout`, which currently duplicates the `DB#BuildInsertStmt` method, `DB#BuildUpsertStmt` supports the exclusion in place without breaking the API and without having to duplicate everything wht it currently does into a separate function just for this.

This is required by the upcoming Icinga Notifications PR of mine that is going to fix:
- https://github.com/Icinga/icinga-notifications/issues/340.