### PR TITLE
notifications: introduce `YieldIncidents` function

### DIFF
--- a/notifications/source/client.go
+++ b/notifications/source/client.go
@@ -18,6 +18,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	// ErrAttrsNegotiation implies missing attributes.
+	ErrAttrsNegotiation = stderrors.New("attribute negotiation required")
+
+	// ErrUnauthorizedRequest indicates that the request was unauthorized, typically due to invalid credentials.
+	ErrUnauthorizedRequest = stderrors.New("unauthorized request")
+
+	// ErrReadPartialResp indicates that a partial response was received from the API, which may require special handling.
+	ErrReadPartialResp = stderrors.New("read partial response")
+)
+
 // clientTransport is a http.RoundTripper to be used in NewClient.
 type clientTransport struct {
 	http.RoundTripper
@@ -111,9 +122,6 @@ func NewClient(cfg Config, clientName string) (*Client, error) {
 	}, nil
 }
 
-// ErrAttrsNegotiation implies missing attributes.
-var ErrAttrsNegotiation = stderrors.New("attribute negotiation required")
-
 // ProcessEvent submits an event.Event to the Icinga Notifications /process-event API endpoint.
 //
 // When rejectIncomplete is set and the returned error is ErrAttrsNegotiation,
@@ -170,27 +178,82 @@ func (client *Client) ProcessEvent(ctx context.Context, ev *event.Event, rejectI
 // be marshaled to JSON. If filter is nil, an error is returned. Please refer to the Icinga Notifications API doc
 // for details on the filter syntax and supported fields.
 func (client *Client) GetIncidents(ctx context.Context, filter any) ([]Incident, error) {
-	if filter == nil {
-		return nil, errors.New("filter parameter must be non-nil")
-	}
-
-	//nolint:bodyclose // False positive, drainBody is called in the defer statement below.
-	resp, err := client.doRequest(ctx, http.MethodGet, client.endpoints.Incidents, filter, nil, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "cannot GET incidents from API")
-	}
-	defer drainBody(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("unexpected response from incidents API, status %q (%d): %q",
-			resp.Status, resp.StatusCode, readLimitedBody(resp.Body))
-	}
-
+	incidentsCh, errCh := client.YieldIncidents(ctx, filter)
 	var incidents []Incident
-	if err := json.NewDecoder(resp.Body).Decode(&incidents); err != nil {
-		return nil, errors.Wrap(err, "cannot decode incidents response")
+
+	for incident := range incidentsCh {
+		incidents = append(incidents, incident)
+	}
+	if err := <-errCh; err != nil {
+		return nil, err
 	}
 	return incidents, nil
+}
+
+// YieldIncidents retrieves the current incidents of this source from the Icinga Notifications /incidents endpoint
+// and yields them as a stream of [Incident] objects.
+//
+// The filter parameter is used to filter the incidents returned by the API. It must be a non-nil value that can
+// be marshaled to JSON. If filter is nil, an error is returned. Please refer to the Icinga Notifications API doc
+// for details on the filter syntax and supported fields.
+//
+// The function returns a channel of [Incident] objects and a channel of errors. The caller should read from both
+// channels until they are closed. If an error occurs during the request or while decoding the response, it will
+// be sent to the error channel. Also, this might send [ErrReadPartialResp] to the error channel when it receives
+// an incident with a non-zero [ErrorState] from the API, which indicates that something went wrong after streaming
+// the first chunk of the response body.
+//
+// If you want to collect all incidents into a slice, consider using [Client.GetIncidents] instead, which internally
+// uses this function and collects the incidents for you.
+func (client *Client) YieldIncidents(ctx context.Context, filter any) (<-chan Incident, <-chan error) {
+	incidentsCh := make(chan Incident)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(incidentsCh)
+		defer close(errCh)
+
+		if filter == nil {
+			errCh <- errors.New("filter parameter must be non-nil")
+			return
+		}
+
+		//nolint:bodyclose // False positive, drainBody is called in the defer statement below.
+		resp, err := client.doRequest(ctx, http.MethodGet, client.endpoints.Incidents, filter, nil, nil)
+		if err != nil {
+			errCh <- errors.Wrap(err, "cannot GET incidents from API")
+			return
+		}
+		defer drainBody(resp.Body)
+
+		if resp.StatusCode != http.StatusAccepted {
+			errCh <- errors.Errorf("unexpected response from incidents API, status %q (%d): %q",
+				resp.Status, resp.StatusCode, readLimitedBody(resp.Body))
+			return
+		}
+
+		for dec := json.NewDecoder(resp.Body); dec.More(); {
+			var incident Incident
+			if err := dec.Decode(&incident); err != nil {
+				errCh <- errors.Wrap(err, "cannot decode incident from response")
+				return
+			}
+
+			if incident.Error != "" {
+				errCh <- errors.Wrap(ErrReadPartialResp, incident.Error)
+				return
+			}
+
+			select {
+			case incidentsCh <- incident:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+	}()
+
+	return incidentsCh, errCh
 }
 
 // ModifyIncidents modifies the incidents that match the provided filter with the given attributes.
@@ -198,6 +261,10 @@ func (client *Client) GetIncidents(ctx context.Context, filter any) ([]Incident,
 // The filter parameter is used to select which incidents to modify. It must be a non-nil value that can be
 // marshaled to JSON. If filter is nil, an error is returned. Please refer to the Icinga Notifications API
 // doc for details on the filter syntax and supported fields.
+//
+// If some matching incidents couldn't be modified, the function returns a [ModifyError] containing the details
+// of the incidents that failed to be modified. The caller can inspect that error to determine and act up the
+// erroneous incidents if needed.
 func (client *Client) ModifyIncidents(ctx context.Context, attrs ModifiableIncidentAttrs, filter any) error {
 	if filter == nil {
 		return errors.New("filter parameter must be non-nil")
@@ -228,15 +295,26 @@ func (client *Client) ModifyIncidents(ctx context.Context, attrs ModifiableIncid
 	}
 	defer drainBody(resp.Body)
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusAccepted {
 		return errors.Errorf("unexpected response from modify incidents API, status %q (%d): %q",
 			resp.Status, resp.StatusCode, readLimitedBody(resp.Body))
 	}
+
+	var results []ModifiedIncidentResp
+	for dec := json.NewDecoder(resp.Body); dec.More(); {
+		var modifiedResp ModifiedIncidentResp
+		if err := dec.Decode(&modifiedResp); err != nil {
+			return errors.Wrap(err, "cannot decode modified incident response from API")
+		}
+		if modifiedResp.Error != "" {
+			results = append(results, modifiedResp)
+		}
+	}
+	if len(results) > 0 {
+		return errors.WithStack(&ModifyError{results: results})
+	}
 	return nil
 }
-
-// ErrUnauthorizedRequest indicates that the request was unauthorized, typically due to invalid credentials.
-var ErrUnauthorizedRequest = stderrors.New("unauthorized request")
 
 // doRequest is a helper function that performs an HTTP request to the specified endpoint with the given method, filter,
 // body, and headers.
@@ -286,11 +364,25 @@ func (client *Client) doRequest(
 	return resp, nil
 }
 
+// ErrorState represents the error state of an incident as returned by the Icinga Notifications /incidents API endpoint.
+type ErrorState struct {
+	Error string `json:"error,omitempty"`
+}
+
 // Incident represents a single incident object as returned by the Icinga Notifications /incidents API endpoint.
+//
+// Since Icinga Notifications streams the response in a NDJSON format, the Error field will be set to a non-zero
+// value when something goes wrong after sending the HTTP response headers and the first chunk of the response body.
+// In that case, such an object will be the last object in the response stream and the client should handle it
+// accordingly. In all other cases, the [ErrState.Error] field will be zero and can be ignored.
+//
+// All other fields are set according to the incident's current state at the time of the request.
 type Incident struct {
 	IsMuted    bool              `json:"is_muted"`
-	ObjectTags map[string]string `json:"object_tags"`
-	Severity   event.Severity    `json:"severity"`
+	ObjectTags map[string]string `json:"object_tags,omitempty"`
+	Severity   event.Severity    `json:"severity,omitempty"`
+
+	ErrorState
 }
 
 // ModifiableIncidentAttrs represents the attributes of an incident that can be modified via the /incident endpoint.
@@ -314,6 +406,17 @@ func (attrs *ModifiableIncidentAttrs) Validate() error {
 	return nil
 }
 
+// ModifiedIncidentResp represents the response for a single incident from the POST /incident endpoint.
+//
+// The ObjectTags field contains the tags of the incident object, but it might not always be populated.
+// In such cases, Icinga Notifications will just populate the [ErrorState] field with the appropriate
+// error message. The caller should check the Error field to determine if the modification was successful
+// or not.
+type ModifiedIncidentResp struct {
+	ObjectTags map[string]string `json:"object_tags,omitempty"`
+	ErrorState
+}
+
 // readLimitedBody reads from the provided [io.ReadCloser] up to 1<<16 bytes and returns it as a string.
 //
 // If an error occurs during reading, the error message is appended to the returned string.
@@ -334,3 +437,16 @@ func drainBody(body io.ReadCloser) {
 	_, _ = io.Copy(io.Discard, body)
 	_ = body.Close()
 }
+
+// ModifyError represents an error that occurred while modifying incidents via the /incident endpoint.
+type ModifyError struct {
+	results []ModifiedIncidentResp
+}
+
+// Error implements the error interface for ModifyError.
+func (e *ModifyError) Error() string {
+	return fmt.Sprintf("failed to modify %d incidents", len(e.results))
+}
+
+// Results returns the slice of [ModifiedIncidentResp] that contains the details of the incidents that failed to be modified.
+func (e *ModifyError) Results() []ModifiedIncidentResp { return e.results }

--- a/notifications/source/client_test.go
+++ b/notifications/source/client_test.go
@@ -1,47 +1,66 @@
 package source
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/notifications/event"
+	"github.com/icinga/icinga-go-library/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClient(t *testing.T) {
+	t.Parallel()
+
 	clientCert, clientKey := generateClientCert(t)
 	clientCertPool := x509.NewCertPool()
 	require.True(t, clientCertPool.AppendCertsFromPEM([]byte(clientCert)))
 
+	writeResp := func(t *testing.T, rw http.ResponseWriter, results []any) {
+		rw.Header().Set("Content-Type", "application/x-ndjson")
+		rw.WriteHeader(http.StatusAccepted)
+
+		ctrl := http.NewResponseController(rw)
+		enc := json.NewEncoder(rw)
+		for _, result := range results {
+			require.NoError(t, enc.Encode(result))
+			require.NoError(t, ctrl.Flush())
+		}
+	}
+
 	tests := []struct {
 		name    string
 		server  func(t *testing.T, h http.Handler) *httptest.Server
-		handler func(t *testing.T, r *http.Request)
+		handler func(t *testing.T, rw http.ResponseWriter, r *http.Request) bool
 		conf    func(srv *httptest.Server) Config
+		verify  func(t *testing.T, err error, result []Incident)
 	}{
 		{
 			name:   "http",
 			server: func(_ *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
-			handler: func(t *testing.T, r *http.Request) {
+			handler: func(t *testing.T, _ http.ResponseWriter, r *http.Request) bool {
 				user, pass, ok := r.BasicAuth()
 				assert.True(t, ok, "expected basic auth")
 				assert.Equal(t, "icinga", user)
 				assert.Equal(t, "insecure", pass)
+				return false
 			},
 			conf: func(srv *httptest.Server) Config {
 				return Config{
@@ -54,11 +73,12 @@ func TestClient(t *testing.T) {
 		{
 			name:   "https",
 			server: func(_ *testing.T, h http.Handler) *httptest.Server { return httptest.NewTLSServer(h) },
-			handler: func(t *testing.T, r *http.Request) {
+			handler: func(t *testing.T, _ http.ResponseWriter, r *http.Request) bool {
 				user, pass, ok := r.BasicAuth()
 				assert.True(t, ok, "expected basic auth")
 				assert.Equal(t, "icinga", user)
 				assert.Equal(t, "insecure", pass)
+				return false
 			},
 			conf: func(srv *httptest.Server) Config {
 				ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
@@ -78,9 +98,10 @@ func TestClient(t *testing.T) {
 				srv.StartTLS()
 				return srv
 			},
-			handler: func(t *testing.T, r *http.Request) {
+			handler: func(t *testing.T, _ http.ResponseWriter, r *http.Request) bool {
 				assert.Len(t, r.TLS.VerifiedChains, 1, "expected one verified cert")
 				assert.Equal(t, r.TLS.VerifiedChains[0][0].Subject.String(), "CN=icinga", "invalid client cert subject")
+				return false
 			},
 			conf: func(srv *httptest.Server) Config {
 				ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
@@ -107,27 +128,125 @@ func TestClient(t *testing.T) {
 			// No handler as this would require OS specific implementations; total overkill for testing.
 			conf: func(srv *httptest.Server) Config { return Config{Url: "unix://" + srv.Listener.Addr().String()} },
 		},
+		{
+			name:   "GetIncidents",
+			server: func(t *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
+			handler: func(t *testing.T, rw http.ResponseWriter, r *http.Request) bool {
+				incidents := []any{
+					Incident{IsMuted: false, ObjectTags: map[string]string{"icinga": "test"}, Severity: event.SeverityCrit},
+					Incident{IsMuted: true, ObjectTags: map[string]string{"icinga": "test2"}, Severity: event.SeverityWarning},
+					Incident{IsMuted: false, ObjectTags: map[string]string{"icinga": "test3"}, Severity: event.SeverityInfo},
+				}
+				writeResp(t, rw, incidents)
+				return true
+			},
+			conf: func(srv *httptest.Server) Config { return Config{Url: srv.URL} },
+			verify: func(t *testing.T, err error, result []Incident) {
+				require.NoError(t, err)
+				assert.Len(t, result, 3)
+				for i, incident := range result {
+					switch i {
+					case 0:
+						assert.Equal(t, event.SeverityCrit, incident.Severity)
+						assert.Equal(t, map[string]string{"icinga": "test"}, incident.ObjectTags)
+					case 1:
+						assert.Equal(t, event.SeverityWarning, incident.Severity)
+						assert.Equal(t, map[string]string{"icinga": "test2"}, incident.ObjectTags)
+					case 2:
+						assert.Equal(t, event.SeverityInfo, incident.Severity)
+						assert.Equal(t, map[string]string{"icinga": "test3"}, incident.ObjectTags)
+					}
+				}
+			},
+		},
+		{
+			name:   "GetIncidents Fail",
+			server: func(t *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
+			handler: func(t *testing.T, rw http.ResponseWriter, r *http.Request) bool {
+				incidents := []any{
+					Incident{IsMuted: false, ObjectTags: map[string]string{"icinga": "test"}, Severity: event.SeverityCrit},
+					Incident{ErrorState: ErrorState{Error: "something went wrong"}},
+				}
+				writeResp(t, rw, incidents)
+				return true
+			},
+			conf: func(srv *httptest.Server) Config { return Config{Url: srv.URL} },
+			verify: func(t *testing.T, err error, result []Incident) {
+				require.ErrorIs(t, err, ErrReadPartialResp)
+				require.ErrorContains(t, err, "something went wrong")
+				assert.Len(t, result, 0)
+			},
+		},
+		{
+			name:   "ModifyIncidents",
+			server: func(t *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
+			handler: func(t *testing.T, rw http.ResponseWriter, r *http.Request) bool {
+				results := []any{
+					ModifiedIncidentResp{ObjectTags: map[string]string{"icinga": "test"}},
+					ModifiedIncidentResp{ObjectTags: map[string]string{"icinga": "test2"}},
+				}
+				writeResp(t, rw, results)
+				return true
+			},
+			conf:   func(srv *httptest.Server) Config { return Config{Url: srv.URL} },
+			verify: func(t *testing.T, err error, _ []Incident) { require.NoError(t, err) },
+		},
+		{
+			name:   "ModifyIncidents Fail",
+			server: func(t *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
+			handler: func(t *testing.T, rw http.ResponseWriter, r *http.Request) bool {
+				results := []any{
+					ModifiedIncidentResp{ObjectTags: map[string]string{"icinga": "test"}},
+					ModifiedIncidentResp{ObjectTags: map[string]string{"icinga": "test2"}, ErrorState: ErrorState{Error: "something went wrong"}},
+				}
+				writeResp(t, rw, results)
+				return true
+			},
+			conf: func(srv *httptest.Server) Config { return Config{Url: srv.URL} },
+			verify: func(t *testing.T, err error, _ []Incident) {
+				var merr *ModifyError
+				require.True(t, errors.As(err, &merr))
+				assert.Len(t, merr.Results(), 1)
+				res := merr.Results()[0]
+				assert.Equal(t, map[string]string{"icinga": "test2"}, res.ObjectTags)
+				assert.Equal(t, "something went wrong", res.Error)
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var reached bool
 			srv := tc.server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				reached = true
 				assert.Equal(t, "test-client", r.Header.Get("User-Agent"))
 				if tc.handler != nil {
-					tc.handler(t, r)
+					if tc.handler(t, w, r) {
+						return // headers and status code already written by handler
+					}
 				}
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(http.StatusAccepted)
 			}))
 			defer srv.Close()
 
 			client, err := NewClient(tc.conf(srv), "test-client")
 			require.NoError(t, err)
 
-			_, err = client.ProcessEvent(context.Background(), &event.Event{}, false)
-			require.NoError(t, err)
+			filter := map[string]any{"something": "unused"}
+			var incidents []Incident
+			if strings.HasPrefix(tc.name, "ModifyIncidents") {
+				err = client.ModifyIncidents(t.Context(), ModifiableIncidentAttrs{Close: types.MakeBool(true)}, filter)
+			} else {
+				incidents, err = client.GetIncidents(t.Context(), filter)
+			}
 			assert.True(t, reached, "request should have reached the server")
+			if tc.verify != nil {
+				tc.verify(t, err, incidents)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
As an alternative to the existing `GetIncidents` function which reads and decodes the entire response body before returning the huge slice of incidents. This new function, on the other hand, reads, decodes and yields a single `source.Incident` object at a time until the EOF.