### PR TITLE
notifications.source: Unix Domain Socket and HTTPS

### DIFF
--- a/notifications/source/client.go
+++ b/notifications/source/client.go
@@ -7,6 +7,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,25 +18,25 @@ import (
 	"github.com/pkg/errors"
 )
 
-// basicAuthTransport is an http.RoundTripper that adds basic authentication and a User-Agent header to HTTP requests.
-type basicAuthTransport struct {
-	http.RoundTripper // RoundTripper is the underlying HTTP transport to use for making requests.
+// clientTransport is a http.RoundTripper to be used in NewClient.
+type clientTransport struct {
+	http.RoundTripper
 
-	// username and password are set as HTTP basic authentication.
+	// userAgent for the User-Agent request header.
+	userAgent string
+
+	// username and password are sent as HTTP basic authentication if the username is not empty.
 	username string
 	password string
-	// userAgent is used to set the User-Agent header.
-	userAgent string
 }
 
-// RoundTrip adds basic authentication headers to the request and executes the HTTP request.
-func (b *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.SetBasicAuth(b.username, b.password)
-	// As long as our round tripper is used for the client, the User-Agent header below
-	// overrides any other value set by the user.
-	req.Header.Set("User-Agent", b.userAgent)
-
-	return b.RoundTripper.RoundTrip(req)
+// RoundTrip implements http.RoundTripper.
+func (ct *clientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", ct.userAgent)
+	if ct.username != "" {
+		req.SetBasicAuth(ct.username, ct.password)
+	}
+	return ct.RoundTripper.RoundTrip(req)
 }
 
 // Client provides a common interface to interact with the Icinga Notifications API.
@@ -65,13 +66,39 @@ func NewClient(cfg Config, clientName string) (*Client, error) {
 	// Clear any query parameters from the base URL not to interfere with the filter query parameter used in requests.
 	baseUrl.RawQuery = ""
 
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+	switch baseUrl.Scheme {
+	case schemeHttp:
+		// Nothing to do here.
+
+	case schemeHttps:
+		cfg.TlsOptions.Enable = true
+		tlsConfig, err := cfg.TlsOptions.MakeConfig(baseUrl.Hostname())
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create TLS config")
+		}
+		transport.TLSClientConfig = tlsConfig
+
+	case schemeUnix:
+		// Extract the socket path used for lower level connection and use a dummy HTTP URL instead.
+		socketPath := baseUrl.Path
+		baseUrl = &url.URL{Scheme: "http", Host: "localhost:5680"}
+		transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			dialer := &net.Dialer{}
+			return dialer.DialContext(ctx, "unix", socketPath)
+		}
+
+	default:
+		return nil, errors.Errorf("unsupported notifications scheme %q", baseUrl.Scheme)
+	}
+
 	return &Client{
 		httpClient: http.Client{
-			Transport: &basicAuthTransport{
-				RoundTripper: http.DefaultTransport,
+			Transport: &clientTransport{
+				RoundTripper: transport,
+				userAgent:    clientName,
 				username:     cfg.Username,
 				password:     cfg.Password,
-				userAgent:    clientName,
 			},
 		},
 		endpoints: struct {

--- a/notifications/source/client_test.go
+++ b/notifications/source/client_test.go
@@ -1,0 +1,160 @@
+package source
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/icinga/icinga-go-library/config"
+	"github.com/icinga/icinga-go-library/notifications/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	clientCert, clientKey := generateClientCert(t)
+	clientCertPool := x509.NewCertPool()
+	require.True(t, clientCertPool.AppendCertsFromPEM([]byte(clientCert)))
+
+	tests := []struct {
+		name    string
+		server  func(t *testing.T, h http.Handler) *httptest.Server
+		handler func(t *testing.T, r *http.Request)
+		conf    func(srv *httptest.Server) Config
+	}{
+		{
+			name:   "http",
+			server: func(_ *testing.T, h http.Handler) *httptest.Server { return httptest.NewServer(h) },
+			handler: func(t *testing.T, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				assert.True(t, ok, "expected basic auth")
+				assert.Equal(t, "icinga", user)
+				assert.Equal(t, "insecure", pass)
+			},
+			conf: func(srv *httptest.Server) Config {
+				return Config{
+					Url:      srv.URL,
+					Username: "icinga",
+					Password: "insecure",
+				}
+			},
+		},
+		{
+			name:   "https",
+			server: func(_ *testing.T, h http.Handler) *httptest.Server { return httptest.NewTLSServer(h) },
+			handler: func(t *testing.T, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				assert.True(t, ok, "expected basic auth")
+				assert.Equal(t, "icinga", user)
+				assert.Equal(t, "insecure", pass)
+			},
+			conf: func(srv *httptest.Server) Config {
+				ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+				return Config{
+					Url:        srv.URL,
+					Username:   "icinga",
+					Password:   "insecure",
+					TlsOptions: config.TLS{TLSCommon: config.TLSCommon{Ca: string(ca)}},
+				}
+			},
+		},
+		{
+			name: "https client cert",
+			server: func(_ *testing.T, h http.Handler) *httptest.Server {
+				srv := httptest.NewUnstartedServer(h)
+				srv.TLS = &tls.Config{ClientAuth: tls.RequireAndVerifyClientCert, ClientCAs: clientCertPool}
+				srv.StartTLS()
+				return srv
+			},
+			handler: func(t *testing.T, r *http.Request) {
+				assert.Len(t, r.TLS.VerifiedChains, 1, "expected one verified cert")
+				assert.Equal(t, r.TLS.VerifiedChains[0][0].Subject.String(), "CN=icinga", "invalid client cert subject")
+			},
+			conf: func(srv *httptest.Server) Config {
+				ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+				return Config{
+					Url: srv.URL,
+					TlsOptions: config.TLS{TLSCommon: config.TLSCommon{
+						Ca:   string(ca),
+						Cert: clientCert,
+						Key:  clientKey,
+					}},
+				}
+			},
+		},
+		{
+			name: "unix",
+			server: func(t *testing.T, h http.Handler) *httptest.Server {
+				ln, err := net.Listen("unix", filepath.Join(t.TempDir(), "sock"))
+				require.NoError(t, err)
+				srv := httptest.NewUnstartedServer(h)
+				srv.Listener = ln
+				srv.Start()
+				return srv
+			},
+			// No handler as this would require OS specific implementations; total overkill for testing.
+			conf: func(srv *httptest.Server) Config { return Config{Url: "unix://" + srv.Listener.Addr().String()} },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var reached bool
+			srv := tc.server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+				assert.Equal(t, "test-client", r.Header.Get("User-Agent"))
+				if tc.handler != nil {
+					tc.handler(t, r)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			client, err := NewClient(tc.conf(srv), "test-client")
+			require.NoError(t, err)
+
+			_, err = client.ProcessEvent(context.Background(), &event.Event{}, false)
+			require.NoError(t, err)
+			assert.True(t, reached, "request should have reached the server")
+		})
+	}
+}
+
+// generateClientCert for HTTPS client certificate testing.
+func generateClientCert(t *testing.T) (string, string) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(23),
+		Subject:               pkix.Name{CommonName: "icinga"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	require.NoError(t, err)
+
+	keyDer, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+
+	certPem := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPem := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDer}))
+
+	return certPem, keyPem
+}

--- a/notifications/source/config.go
+++ b/notifications/source/config.go
@@ -1,20 +1,43 @@
 package source
 
 import (
+	"net/url"
+
 	"github.com/icinga/icinga-go-library/config"
+	"github.com/pkg/errors"
+)
+
+const (
+	// Supported URI schemes in Config.Url.
+	schemeHttp  = "http"
+	schemeHttps = "https"
+	schemeUnix  = "unix"
 )
 
 // Config defines all configuration for the Icinga Notifications API Client.
 type Config struct {
-	// Url points to the Icinga Notifications API, e.g., http://localhost:5680
+	// Url of the Icinga Notifications API.
+	//
+	// A transport is chosen based on the URI scheme:
+	//   - http: Unencrypted HTTP connection. Requires Username and Password/PasswordFile to be set.
+	//     For example: http://example.com:5680
+	//   - https: HTTPS connection. Either Username and Password/PasswordFile or TlsOptions.{Cert,Key} are required.
+	//     For example: https://example.com:5680
+	//   - unix: HTTP connection over a Unix Domain Socket. Authentication is based on the operating system user.
+	//     So, Username or Password/PasswordFile must not be set. For example: unix:///path/to/socket
 	Url string `yaml:"url" env:"URL"`
 
 	// Username is the API user for the Icinga Notifications API.
+	//
+	// Based on the Config.Url scheme, Username and Password/PasswordFile are either required, allowed, or forbidden.
 	Username string `yaml:"username" env:"USERNAME"`
 
 	// Password is the API user's password for the Icinga Notifications API.
 	Password     string `yaml:"password" env:"PASSWORD,unset"` // #nosec G117 -- exported password field
 	PasswordFile string `yaml:"password_file" env:"PASSWORD_FILE"`
+
+	// TlsOptions are relevant for the "https" Url scheme.
+	TlsOptions config.TLS `yaml:",inline"`
 
 	// DefaultRelations to always resolve and include in the events submitted to Icinga Notifications.
 	DefaultRelations []string `yaml:"default_relations" env:"DEFAULT_RELATIONS"`
@@ -22,8 +45,51 @@ type Config struct {
 
 // Validate the configuration, implements config.Validator.
 func (c *Config) Validate() error {
-	if err := config.LoadPasswordFile(&c.Password, c.PasswordFile); err != nil {
-		return err
+	if c.Url == "" {
+		// Validate an empty, unconfigured config, such as the commented out default in Icinga DB.
+		return nil
+	}
+
+	u, err := url.Parse(c.Url)
+	if err != nil {
+		return errors.Wrap(err, "cannot parse notifications configuration URL")
+	}
+
+	switch u.Scheme {
+	case schemeHttp:
+		if err := config.LoadPasswordFile(&c.Password, c.PasswordFile); err != nil {
+			return err
+		}
+		if c.Username == "" || c.Password == "" {
+			return errors.New("http notifications source requires a username and password")
+		}
+
+	case schemeHttps:
+		c.TlsOptions.Enable = true
+		if c.TlsOptions.Cert == "" && c.Username == "" {
+			return errors.New("https notifications source requires either certificates or username and password")
+		}
+
+		if (c.TlsOptions.Cert == "") != (c.TlsOptions.Key == "") {
+			return errors.New("https notifications source requires either both cert and key or none")
+		}
+
+		if c.Username != "" {
+			if err := config.LoadPasswordFile(&c.Password, c.PasswordFile); err != nil {
+				return err
+			}
+			if c.Password == "" {
+				return errors.New("https notifications source with a username require a password")
+			}
+		}
+
+	case schemeUnix:
+		if c.Username != "" || c.Password != "" || c.PasswordFile != "" {
+			return errors.New("unix notifications source uses no username/password authentication")
+		}
+
+	default:
+		return errors.Errorf("unsupported notifications scheme %q", u.Scheme)
 	}
 
 	return nil

--- a/notifications/source/config_test.go
+++ b/notifications/source/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/testutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig(t *testing.T) {
@@ -15,7 +16,7 @@ func TestConfig(t *testing.T) {
 
 	configTests := []testutils.TestCase[Config, testutils.ConfigTestData]{
 		{
-			Name: "Minimal config",
+			Name: "HTTP config",
 			Data: testutils.ConfigTestData{
 				Yaml: `
 url: http://localhost:5680
@@ -34,7 +35,7 @@ password: secret`,
 			},
 		},
 		{
-			Name: "Minimal config with password file",
+			Name: "HTTP config with password file",
 			Data: testutils.ConfigTestData{
 				Yaml: fmt.Sprintf(`
 url: http://localhost:5680
@@ -51,6 +52,122 @@ password_file: %s`, passwordFile),
 				Username:     "icinga",
 				Password:     "secret",
 				PasswordFile: passwordFile,
+			},
+		},
+		{
+			Name: "HTTP config missing credentials",
+			Data: testutils.ConfigTestData{
+				Yaml: `url: http://localhost:5680`,
+				Env: map[string]string{
+					"URL": "http://localhost:5680",
+				},
+			},
+			Error: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "requires a username and password")
+			},
+		},
+		{
+			Name: "HTTPS config",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+url: https://localhost:5680
+username: icinga
+password: secret`,
+				Env: map[string]string{
+					"URL":      "https://localhost:5680",
+					"USERNAME": "icinga",
+					"PASSWORD": "secret",
+				},
+			},
+			Expected: Config{
+				Url:        "https://localhost:5680",
+				Username:   "icinga",
+				Password:   "secret",
+				TlsOptions: config.TLS{TLSCommon: config.TLSCommon{Enable: true}},
+			},
+		},
+		{
+			Name: "HTTPS config with password file",
+			Data: testutils.ConfigTestData{
+				Yaml: fmt.Sprintf(`
+url: https://localhost:5680
+username: icinga
+password_file: %s`, passwordFile),
+				Env: map[string]string{
+					"URL":           "https://localhost:5680",
+					"USERNAME":      "icinga",
+					"PASSWORD_FILE": passwordFile,
+				},
+			},
+			Expected: Config{
+				Url:          "https://localhost:5680",
+				Username:     "icinga",
+				Password:     "secret",
+				PasswordFile: passwordFile,
+				TlsOptions:   config.TLS{TLSCommon: config.TLSCommon{Enable: true}},
+			},
+		},
+		{
+			Name: "HTTPS config with client cert",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+url: https://localhost:5680
+cert: /client.crt
+key: /client.key`,
+				Env: map[string]string{
+					"URL":  "https://localhost:5680",
+					"CERT": "/client.crt",
+					"KEY":  "/client.key",
+				},
+			},
+			Expected: Config{
+				Url: "https://localhost:5680",
+				TlsOptions: config.TLS{TLSCommon: config.TLSCommon{
+					Enable: true,
+					Cert:   "/client.crt",
+					Key:    "/client.key",
+				}},
+			},
+		},
+		{
+			Name: "HTTPS config missing credentials",
+			Data: testutils.ConfigTestData{
+				Yaml: `url: https://localhost:5680`,
+				Env: map[string]string{
+					"URL": "https://localhost:5680",
+				},
+			},
+			Error: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "requires either certificates or username and password")
+			},
+		},
+		{
+			Name: "Unix domain socket config",
+			Data: testutils.ConfigTestData{
+				Yaml: `url: unix:///path/to/socket`,
+				Env: map[string]string{
+					"URL": "unix:///path/to/socket",
+				},
+			},
+			Expected: Config{
+				Url: "unix:///path/to/socket",
+			},
+		},
+		{
+			Name: "Unix domain socket config with credentials",
+			Data: testutils.ConfigTestData{
+				Yaml: `
+url: unix:///path/to/socket
+username: icinga
+password: secret`,
+				Env: map[string]string{
+					"URL":      "unix:///path/to/socket",
+					"USERNAME": "icinga",
+					"PASSWORD": "secret",
+				},
+			},
+			Error: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "uses no username/password authentication")
 			},
 		},
 		{
@@ -75,6 +192,18 @@ default_relations:
 				Username:         "icinga",
 				Password:         "secret",
 				DefaultRelations: []string{"host.vars", "services[*].vars"},
+			},
+		},
+		{
+			Name: "Invalid URL scheme",
+			Data: testutils.ConfigTestData{
+				Yaml: `url: invalid:nope`,
+				Env: map[string]string{
+					"URL": "invalid:nope",
+				},
+			},
+			Error: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "unsupported notifications scheme")
 			},
 		},
 	}


### PR DESCRIPTION
Support both Unix Domain Sockets and HTTPS as alternative transports for the notifications source client. Based on the URL's scheme, a transport is chosen and different constraints are applied for the configuration.

---

So far, I have tested this change with Icinga DB - where I bumped the IGL to this branch - and Icinga Notifications either at the `main` branch for the Unix Domain Socket and HTTPS w/ Basic Auth or at Icinga/icinga-notifications#454 for TLS Client Certificates.

There, I realized that Go's HTTP module is more picky than `curl(1)` regarding server certificates, expecting a SAN. Thus, for creating certs adjust my [prior comment](https://github.com/Icinga/icinga-notifications/pull/454#pullrequestreview-4633722749) with this modification for the server certificate.

```
$ cat server_cert.ext
subjectKeyIdentifier   = hash
authorityKeyIdentifier = keyid:always,issuer:always
basicConstraints       = CA:TRUE
keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign
subjectAltName         = DNS:example.com, DNS:*.example.com
issuerAltName          = issuer:copy

$ openssl x509 -req -days 1 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile server_cert.ext -out server.crt
```

Refs Icinga/icingadb#1113.